### PR TITLE
Update golang to 1.16

### DIFF
--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4 as builder
+FROM golang:1.16.7 as builder
 
 WORKDIR /go/github.com/jetstack/preflight
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jetstack/preflight
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Azure/aks-engine v0.56.0

--- a/go.sum
+++ b/go.sum
@@ -557,7 +557,6 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/jarcoal/httpmock v1.0.1 h1:OXIOrglWeSllwHQGJ5X4PX4hFZK1DPCXSJVhMSJacg8=
 github.com/jarcoal/httpmock v1.0.1/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jetstack/version-checker v0.2.2-0.20201118163251-4bab9ef088ef h1:bsZIh0Y7TogJfmseOARM9OeZzctSDuuHuJQTQhl97Mo=


### PR DESCRIPTION
Updating the agent to use golang version 1.16 rather than 1.13.
Allows us to use new golang features, like embedded files

Signed-off-by: oluwole.fadeyi <oluwole.fadeyi@jetstack.io>