### PR TITLE
Send secret annotations to platform

### DIFF
--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -61,31 +61,17 @@ func getSecret(name, namespace string, data map[string]interface{}, isTLS bool, 
 	}
 
 	metadata, _ := object.Object["metadata"].(map[string]interface{})
+	annotations := make(map[string]interface{})
 
 	// if we're creating a 'raw' secret as scraped that was applied by kubectl
 	if withLastApplied {
 		jsonData, _ := json.Marshal(data)
-		metadata["annotations"] = map[string]interface{}{
-			"kubectl.kubernetes.io/last-applied-configuration": string(jsonData),
-		}
+		annotations["kubectl.kubernetes.io/last-applied-configuration"] = string(jsonData)
 	}
+
+	metadata["annotations"] = annotations
 
 	return object
-}
-
-func asUnstructuredList(items ...*unstructured.Unstructured) *unstructured.UnstructuredList {
-	itemsNonPtr := make([]unstructured.Unstructured, len(items))
-	for i, u := range items {
-		itemsNonPtr[i] = *u
-	}
-	return &unstructured.UnstructuredList{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"resourceVersion": "",
-			},
-		},
-		Items: itemsNonPtr,
-	}
 }
 
 func sortGatheredResources(list []*api.GatheredResource) {

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -14,6 +14,7 @@ import (
 var SecretSelectedFields = []string{
 	"kind",
 	"apiVersion",
+	"metadata.annotations",
 	"metadata.name",
 	"metadata.namespace",
 	"metadata.ownerReferences",


### PR DESCRIPTION
To allow users to filter out system certificates, we need to check their annotations. Currently, the agent does not send these.

This commit modifies the agent to provide annotations in the request to the backend