### PR TITLE
Open shift route filter

### DIFF
--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -282,7 +282,7 @@ func redactList(list []*api.GatheredResource) error {
 				Select(SecretSelectedFields, resource)
 
 				// route object
-			} else if gvk.Kind == "Route" && gvk.Group == "apiextensions.k8s.io" {
+			} else if gvk.Kind == "Route" && gvk.Group == "route.openshift.io" {
 				Select(RouteSelectedFields, resource)
 
 				// break once a Secret or Route object has been processed as, no

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -281,15 +281,11 @@ func redactList(list []*api.GatheredResource) error {
 			if gvk.Kind == "Secret" && (gvk.Group == "core" || gvk.Group == "") {
 				Select(SecretSelectedFields, resource)
 
-				// break when the object has been processed as a secret, no
-				// other kinds have redact modifications
-				break
-
 				// route object
-			} else if gvk.Kind == "Route" && (gvk.Group == "core" || gvk.Group == "") {
+			} else if gvk.Kind == "Route" && gvk.Group == "apiextensions.k8s.io" {
 				Select(RouteSelectedFields, resource)
 
-				// break when the object has been processed as a Route, no
+				// break once a Secret or Route object has been processed as, no
 				// other kinds have redact modifications
 				break
 			}

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -285,7 +285,6 @@ func redactList(list []*api.GatheredResource) error {
 			} else if gvk.Kind == "Route" && gvk.Group == "route.openshift.io" {
 				Select(RouteSelectedFields, resource)
 			}
-
 		}
 
 		// remove managedFields from all resources

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jetstack/preflight/api"
-	"github.com/jetstack/preflight/pkg/datagatherer"
 	"github.com/pkg/errors"
 	"github.com/pmylund/go-cache"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +17,9 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8scache "k8s.io/client-go/tools/cache"
+
+	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/datagatherer"
 )
 
 // ConfigDynamic contains the configuration for the data-gatherer.
@@ -274,12 +275,21 @@ func redactList(list []*api.GatheredResource) error {
 
 		resource := item
 
+		// Redact item if it is a:
 		for _, gvk := range gvks {
-			// If this item is a Secret then we need to redact it.
+			// secret object
 			if gvk.Kind == "Secret" && (gvk.Group == "core" || gvk.Group == "") {
 				Select(SecretSelectedFields, resource)
 
 				// break when the object has been processed as a secret, no
+				// other kinds have redact modifications
+				break
+
+				// route object
+			} else if gvk.Kind == "Route" && (gvk.Group == "core" || gvk.Group == "") {
+				Select(RouteSelectedFields, resource)
+
+				// break when the object has been processed as a Route, no
 				// other kinds have redact modifications
 				break
 			}

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -284,10 +284,6 @@ func redactList(list []*api.GatheredResource) error {
 				// route object
 			} else if gvk.Kind == "Route" && gvk.Group == "route.openshift.io" {
 				Select(RouteSelectedFields, resource)
-
-				// break once a Secret or Route object has been processed as, no
-				// other kinds have redact modifications
-				break
 			}
 
 		}

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -25,6 +25,26 @@ var SecretSelectedFields = []string{
 	"/data/ca.crt",
 }
 
+// RouteSelectedFields is the list of fields sent from OpenShift Route objects to the
+// backend
+var RouteSelectedFields = []string{
+	"kind",
+	"apiVersion",
+	"metadata.annotations",
+	"metadata.name",
+	"metadata.namespace",
+	"metadata.ownerReferences",
+	"metadata.selfLink",
+	"metadata.uid",
+	"spec.host",
+	"spec.to.kind",
+	"spec.to.name",
+	"spec.tls.termination",
+	"spec.tls.certificate",
+	"spec.tls.caCertificate",
+	"spec.tls.destinationCACertificate",
+}
+
 // RedactFields are removed from all objects
 var RedactFields = []string{
 	"metadata.managedFields",

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -38,11 +38,16 @@ var RouteSelectedFields = []string{
 	"metadata.uid",
 	"spec.host",
 	"spec.to.kind",
+	"spec.to.port",
 	"spec.to.name",
+	"spec.to.weight",
 	"spec.tls.termination",
 	"spec.tls.certificate",
 	"spec.tls.caCertificate",
 	"spec.tls.destinationCACertificate",
+	"spec.tls.insecureEdgeTerminationPolicy",
+	"spec.wildcardPolicy",
+	"status",
 }
 
 // RedactFields are removed from all objects

--- a/pkg/datagatherer/k8s/fieldfilter_test.go
+++ b/pkg/datagatherer/k8s/fieldfilter_test.go
@@ -120,7 +120,7 @@ func TestSelect(t *testing.T) {
 		"route":  {routeResource, routeFieldsToSelect, routeExpectedJSON},
 	}
 
-	for resource, test := range tests {
+	for name, test := range tests {
 		err := Select(test.fieldsToSelect, test.resource)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -128,9 +128,11 @@ func TestSelect(t *testing.T) {
 
 		bytes, err := json.MarshalIndent(test.resource, "", "    ")
 
-		if string(bytes) != test.expectedJSON {
-			t.Fatalf("%s test failed, unexpected JSON: \ngot \n%s\nwant\n%s", resource, string(bytes), test.expectedJSON)
-		}
+		t.Run(name, func(t *testing.T) {
+			if string(bytes) != test.expectedJSON {
+				t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(bytes), test.expectedJSON)
+			}
+		})
 	}
 }
 

--- a/pkg/datagatherer/k8s/fieldfilter_test.go
+++ b/pkg/datagatherer/k8s/fieldfilter_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestSelect(t *testing.T) {
-	resource := &unstructured.Unstructured{
+	// secret objects
+	secretResource := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "Secret",
@@ -27,7 +28,7 @@ func TestSelect(t *testing.T) {
 		},
 	}
 
-	fieldsToSelect := []string{
+	secretFieldsToSelect := []string{
 		"apiVersion",
 		"kind",
 		"metadata.name",
@@ -36,13 +37,7 @@ func TestSelect(t *testing.T) {
 		"/data/tls.crt",
 	}
 
-	err := Select(fieldsToSelect, resource)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	bytes, err := json.MarshalIndent(resource, "", "    ")
-	expectedJSON := `{
+	secretExpectedJSON := `{
     "apiVersion": "v1",
     "data": {
         "tls.crt": "cert data"
@@ -54,8 +49,88 @@ func TestSelect(t *testing.T) {
     },
     "type": "kubernetes.io/tls"
 }`
-	if string(bytes) != expectedJSON {
-		t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(bytes), expectedJSON)
+	// route objects
+	routeResource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Route",
+			"metadata": map[string]interface{}{
+				"name": "example",
+				"annotations": map[string]string{
+					"kubectl.kubernetes.io/last-applied-configuration": "secret",
+				},
+			},
+			"spec": map[string]interface{}{
+				"host": "www.example.com",
+				"to": map[string]string{
+					"kind": "Service",
+					"name": "frontend",
+				},
+				"tls": map[string]interface{}{
+					"termination":              "reencrypt",
+					"key":                      "secret",
+					"certificate":              "cert data",
+					"caCertificate":            "caCert data",
+					"destinationCACertificate": "destinationCaCert data",
+				},
+			},
+		},
+	}
+
+	routeFieldsToSelect := []string{
+		"apiVersion",
+		"kind",
+		"metadata.name",
+		"spec.host",
+		"spec.to.kind",
+		"spec.to.name",
+		"spec.tls.termination",
+		"spec.tls.certificate",
+		"spec.tls.caCertificate",
+		"spec.tls.destinationCACertificate",
+	}
+
+	routeExpectedJSON := `{
+    "apiVersion": "v1",
+    "kind": "Route",
+    "metadata": {
+        "name": "example"
+    },
+    "spec": {
+        "host": "www.example.com",
+        "tls": {
+            "caCertificate": "caCert data",
+            "certificate": "cert data",
+            "destinationCACertificate": "destinationCaCert data",
+            "termination": "reencrypt"
+        },
+        "to": {
+            "kind": "Service",
+            "name": "frontend"
+        }
+    }
+}`
+
+	tests := map[string]struct {
+		resource       *unstructured.Unstructured
+		fieldsToSelect []string
+		expectedJSON   string
+	}{
+		"secret": {secretResource, secretFieldsToSelect, secretExpectedJSON},
+		"route":  {routeResource, routeFieldsToSelect, routeExpectedJSON},
+	}
+
+	for resource, test := range tests {
+		err := Select(test.fieldsToSelect, test.resource)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		bytes, err := json.MarshalIndent(test.resource, "", "    ")
+
+		if string(bytes) != test.expectedJSON {
+			t.Fatalf("%s test failed, unexpected JSON: \ngot \n%s\nwant\n%s", resource, string(bytes), test.expectedJSON)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR is to exclude sensitive fields from OpenShift Route resources.

It is likely further changes are required before the PR can be approved & merged.

Two of the main issues I can think of are:
1. I was not able to establish with absolute certainty what fields the **Route** resource has and which of these we want to keep. If the [defined fields](https://github.com/jetstack/jetstack-secure/blob/2605a7512be45e3b3007c48686e9866ce9953052/pkg/datagatherer/k8s/fieldfilter.go#L28-L46) are not correct, further changes are required. [This](https://docs.openshift.com/container-platform/4.8/networking/routes/route-configuration.html#nw-ingress-creating-a-route-via-an-ingress_route-configuration) (see the _YAML Definition of an autogenerated route_) so far is the most relevant OpenShift documentation I could find that lists the fields.
2. I am not sure if the [logic I used to select fields for secrets and routes](https://github.com/jetstack/jetstack-secure/blob/2605a7512be45e3b3007c48686e9866ce9953052/pkg/datagatherer/k8s/dynamic.go#L279-L297) e.g. why/when should I be breaking out of the inner loop
3. I am not entirely sure of Routes api group [seems to be `route.openshift.io`](https://github.com/openshift/router/blob/5ecca61eb85d72f2f38564daa33410c4655e429e/deploy/route_crd.yaml#L8) but I am not sure if my assumption is correct.

I assume there are other things that need to be addressed so this is at this stage still a work in progress.