### PR TITLE
Add signing, provenance and SBOM

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -44,7 +44,7 @@ jobs:
       id-token: write
     steps:
     - name: Install Tools
-      run: apk add --update make git jq rsync curl bash
+      run: apk add --update make git jq rsync curl bash coreutils
     - name: Install cosign
       uses: sigstore/cosign-installer@51f8e5c6fce54e46006ae97d73b2b6315f518752
       with:

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -38,9 +38,19 @@ jobs:
         env:
           DOCKER_DRIVER: overlay
           DOCKER_HOST: tcp://localhost:2375
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
     - name: Install Tools
-      run: apk add --update make git jq rsync curl
+      run: apk add --update make git jq rsync curl bash
+    - name: Install cosign
+      uses: sigstore/cosign-installer@51f8e5c6fce54e46006ae97d73b2b6315f518752
+      with:
+        cosign-release: v1.5.2
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@3626d7d7b13e87ee6c6f9ded3940dea05a3967bc
     - uses: actions/checkout@v2.4.0
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -48,11 +58,39 @@ jobs:
       uses: docker/setup-buildx-action@v1
       with:
         driver-opts: image=moby/buildkit:master
-    - name: Login to registry
+    - name: Login to quay.io
       uses: docker/login-action@v1
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_PASSWORD }}
+    - name: Login to ghcr.io
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       run: make push-docker-image
+    - name: Sign
+      run: make sign-docker-image
+    - name: SBOM
+      run: make sbom-docker-image
+    # The slsa-provenance-action generates a full attestation from an artifact
+    # as the subject. However, cosign only expects the predicate portion of
+    # the attestation and figures out the subject itself from the image.
+    #
+    # So, we generate a fake artifact and then strip everything but the
+    # predicate out from the generated attestation.
+    - name: Create mock artifact
+      run: echo "foobar" > mock
+    - name: Generate provenance
+      uses: philips-labs/SLSA-Provenance-Action@dddb40e199ae28d4cd2f17bad7f31545556fdd3d
+      with:
+        command: generate
+        subcommand: files
+        arguments: --artifact-path mock
+    - name: Extract predicate
+      run: jq '.predicate' provenance.json > predicate.json
+    - name: Attest
+      run: make attest-docker-image

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -44,6 +44,9 @@ jobs:
       id-token: write
     steps:
     - name: Install Tools
+      # Installing 'bash' because it's required by the 'cosign-installer' action
+      # and 'coreutils' because the 'slsa-provenance-action' requires a version
+      # of 'base64' that supports the -w flag.
       run: apk add --update make git jq rsync curl bash coreutils
     - name: Install cosign
       uses: sigstore/cosign-installer@51f8e5c6fce54e46006ae97d73b2b6315f518752

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ credentials.json
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+bom.xml
+predicate.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ SaaS](https://platform.jetstack.io).
 Please [review the documentation](https://platform.jetstack.io/docs/agent) for
 the agent on to get started.
 
+The released container images are cryptographically signed by
+[`cosign`](https://github.com/sigstore/cosign), with
+[SLSA provenance](https://slsa.dev/provenance/v0.2) and a
+[CycloneDX SBOM](https://cyclonedx.org/) attached. For instructions on how to
+verify those signatures and attachments, refer to
+[this guide](docs/guides/cosign).
+
 ## Local Execution
 
 To build and run a version from master:

--- a/docs/guides/cosign/guide.md
+++ b/docs/guides/cosign/guide.md
@@ -1,0 +1,93 @@
+# Cosign
+
+> Note: the ['keyless' signing feature](https://github.com/sigstore/cosign/blob/main/KEYLESS.md)
+> of `cosign` used here is currently classified as 'experimental'
+
+The jetstack-secure agent container image is signed using
+[`cosign`](https://github.com/sigstore/cosign).
+
+An attestation is attached which satisfies the requirements of
+[SLSA 1](https://slsa.dev/spec/v0.1/requirements) and a
+[CycloneDX Software Bill of Materials](https://cyclonedx.org/) is also provided
+that details the dependencies of the image.
+
+This document outlines how to verify the signature, attestation and download
+the SBOM with the `cosign` CLI.
+
+## Signature
+
+To verify the container image signature:
+
+1. Ensure `cosign` is installed
+2. Configure the signature repository and enable experimental features:
+
+```
+export COSIGN_REPOSITORY=ghcr.io/jetstack/jetstack-secure/cosign
+export COSIGN_EXPERIMENTAL=1
+```
+
+3. Verify the image
+
+```
+cosign verify --cert-oidc-issuer https://token.actions.githubusercontent.com quay.io/jetstack/preflight:latest
+```
+
+If the container was properly signed then the command should exit successfully.
+
+The `Subject` in the output should be
+`https://github.com/jetstack/jetstack-secure/.github/workflows/release-master.yaml@<ref>`,
+where `<ref>` is either the `master` branch or a release tag, i.e:
+
+- `refs/branch/master`
+- `refs/tags/v0.1.35`
+
+## SLSA Provenance Attestation
+
+To verify and view the SLSA provenance attestation:
+
+1. Ensure `cosign` is installed
+2. Configure the signature repository and enable experimental features:
+
+```
+export COSIGN_REPOSITORY=ghcr.io/jetstack/jetstack-secure/cosign
+export COSIGN_EXPERIMENTAL=1
+```
+
+3. Verify and decode the attestation payload:
+
+```
+cosign verify-attestation --cert-oidc-issuer https://token.actions.githubusercontent.com quay.io/jetstack/preflight:latest | tail -n 1 | jq -r .payload | base64 -d | jq -r .
+```
+
+## Software Bill of Materials (SBOM)
+
+To verify and download the SBOM:
+
+1. Ensure `cosign` is installed
+2. Configure the signature repository and enable experimental features:
+
+```
+export COSIGN_REPOSITORY=ghcr.io/jetstack/jetstack-secure/cosign
+export COSIGN_EXPERIMENTAL=1
+```
+
+3. Verify the SBOM
+
+```
+cosign verify --attachment sbom --cert-oidc-issuer https://token.actions.githubusercontent.com quay.io/jetstack/preflight:latest
+```
+
+If the SBOM was properly signed then the command should exit successfully.
+
+The `Subject` in the output should be
+`https://github.com/jetstack/jetstack-secure/.github/workflows/release-master.yaml@<ref>`,
+where `<ref>` is either the `master` branch or a release tag, i.e:
+
+- `refs/branch/master`
+- `refs/tags/v0.1.35`
+
+4. Download the SBOM
+
+```
+cosign download sbom quay.io/jetstack/preflight:latest > bom.xml
+```

--- a/docs/guides/cosign/guide.md
+++ b/docs/guides/cosign/guide.md
@@ -38,7 +38,7 @@ The `Subject` in the output should be
 `https://github.com/jetstack/jetstack-secure/.github/workflows/release-master.yaml@<ref>`,
 where `<ref>` is either the `master` branch or a release tag, i.e:
 
-- `refs/branch/master`
+- `refs/heads/master`
 - `refs/tags/v0.1.35`
 
 ## SLSA Provenance Attestation
@@ -83,7 +83,7 @@ The `Subject` in the output should be
 `https://github.com/jetstack/jetstack-secure/.github/workflows/release-master.yaml@<ref>`,
 where `<ref>` is either the `master` branch or a release tag, i.e:
 
-- `refs/branch/master`
+- `refs/heads/master`
 - `refs/tags/v0.1.35`
 
 4. Download the SBOM


### PR DESCRIPTION
Signs the agent container image with cosign's keyless signing and Github OIDC. Also signs and attaches a SLSA provenance attestation and a CycloneDX SBOM.

The provenance provided takes the agent up to SLSA 1.

The signatures and other attachments are stored in a separate repository to the actual container images. There are two main reasons for this:
1. Although quay.io supports cosign signatures as of the latest release, it doesn't support uploading attestations or SBOMs.
2. Pulling SBOMs, attestations and signatures for verification can skew image pull metrics for the repository. The number of pulls strikes me as something we might want to track reliably for the agent.