### PR TITLE
Add pprof profiling endpoints to the agent

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -117,4 +117,11 @@ func init() {
 		os.Getenv("API_TOKEN"),
 		"Token used for authentication when API tokens are in use on the backend",
 	)
+	agentCmd.PersistentFlags().BoolVarP(
+		&agent.Profiling,
+		"enable-pprof",
+		"",
+		false,
+		"Enables the pprof profiling server on the agent (port: 6060).",
+	)
 }


### PR DESCRIPTION
This adds a pprof server running on 6060 to aid in investigating memory
usage of the agents. This can be eneabled or disable through a flag
`profiling`

Signed-off-by: oluwole.fadeyi <oluwole.fadeyi@jetstack.io>