### PR TITLE
Add prometheus server

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -124,4 +124,11 @@ func init() {
 		false,
 		"Enables the pprof profiling server on the agent (port: 6060).",
 	)
+	agentCmd.PersistentFlags().BoolVarP(
+		&agent.Prometheus,
+		"enable-metrics",
+		"",
+		false,
+		"Enables Prometheus metrics server on the agent (port: 8081).",
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/maxatome/go-testdeep v1.11.0
 	github.com/pkg/errors v0.9.1
 	github.com/pmylund/go-cache v2.1.0+incompatible
+	github.com/prometheus/client_golang v1.9.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
This PR adds a prometheus server to agent hidden behind the
enable-metrics flag on port 8081. This is used for debugging purposes.

Signed-off-by: oluwole.fadeyi <oluwole.fadeyi@jetstack.io>