### PR TITLE
Replace json/encoder with jsoniter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
 	k8s.io/client-go v11.0.0+incompatible
+	github.com/json-iterator/go v1.1.12
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -581,6 +581,8 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -697,6 +699,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -23,6 +22,7 @@ import (
 	"github.com/jetstack/preflight/pkg/datagatherer"
 	dgerror "github.com/jetstack/preflight/pkg/datagatherer/error"
 	"github.com/jetstack/preflight/pkg/version"
+	json "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 )

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -1,11 +1,11 @@
 package k8s
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/Jeffail/gabs/v2"
+	json "github.com/json-iterator/go"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 


### PR DESCRIPTION
Currently the Agent running on larger clusters, i.e: Openshift, or clusters with many thousands of resources seem to be use quite a bit of memory hitting the current memory limits (200M) and might get OOM killed.
In order to reduce the memory usage we are going substitute golang json encoder library with https://github.com/json-iterator/go, from pprof we can both Marshalling and Unmarshalling hug much of the cumulative memory.
**PPROF profile  (vanilla agent)**
![out-master-stable1](https://user-images.githubusercontent.com/16049411/160850832-c6bccba8-0665-4162-9665-07be01faf4b7.png)
![out-master-stable-IV](https://user-images.githubusercontent.com/16049411/160852534-32555b80-c0b5-4c91-a38b-b0c45fc1dc1f.png)
**Prometheus inuse memory (vanilla agent)**
![image](https://user-images.githubusercontent.com/16049411/160851087-7636c42d-2525-4076-9b16-4de5225c097e.png)

The average memory use seems to be ~ 170 MB for a vanilla agent in an Openshift cluster.

```
kubectl get pod --all-namespaces | wc -l
334
kubectl get secrets --all-namespaces | wc -l
1619
kubectl get statefulsets.apps --all-namespaces | wc -l
5
kubectl get deployments.apps --all-namespaces | wc -l
76
kubectl get jobs.batch --all-namespaces | wc -l33
kubectl get cronjobs.batch --all-namespaces | wc -l
13
kubectl get daemonsets.apps --all-namespaces | wc -l
22
kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io --all-namespaces | wc -l
3
kubectl get svc --all-namespaces | wc -l
114
```

When replacing the json encoder we now get an average memory usage of ~ 117MB on the same cluster.
**Prometheus inuse memory (new agent)**
![image](https://user-images.githubusercontent.com/16049411/160852428-7691b521-71a3-4111-9a28-0b0e34ee645f.png)
**PPROF profile (new agent)**
![out-refactoringIII-stable-V](https://user-images.githubusercontent.com/16049411/160852807-23a963e6-b5ab-4f1e-be97-32d0af68c65d.png)


Signed-off-by: Oluwole Fadeyi <oluwole.fadeyi@jetstack.io>