### PR TITLE
Refactor k8d/dynamic datagatherer

### DIFF
--- a/pkg/datagatherer/k8s/cache.go
+++ b/pkg/datagatherer/k8s/cache.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jetstack/preflight/api"
 	"github.com/pmylund/go-cache"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // time interface, this is used to fetch the current time
@@ -24,60 +24,52 @@ func (*realTime) now() time.Time {
 	return time.Now()
 }
 
+type cacheResource interface {
+	GetUID() types.UID
+	GetNamespace() string
+}
+
 // onAdd handles the informer creation events, adding the created runtime.Object
 // to the data gatherer's cache. The cache key is the uid of the object
 func onAdd(obj interface{}, dgCache *cache.Cache) {
-	item := obj.(*unstructured.Unstructured)
-	if metadata, ok := item.Object["metadata"]; ok {
-		data := metadata.(map[string]interface{})
-		if uid, ok := data["uid"]; ok {
-			cacheObject := &api.GatheredResource{
-				Resource: obj,
-			}
-			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
-		} else {
-			log.Printf("could not %q resource %q to the cache, missing uid field", "add", data["name"].(string))
+	item, ok := obj.(cacheResource)
+	if ok {
+		cacheObject := &api.GatheredResource{
+			Resource: obj,
 		}
-	} else {
-		log.Printf("could not %q resource to the cache, missing metadata", "add")
+		dgCache.Set(string(item.GetUID()), cacheObject, cache.DefaultExpiration)
+		return
 	}
+	log.Printf("could not %q resource to the cache, missing metadata/uid field", "add")
+
 }
 
 // onUpdate handles the informer update events, replacing the old object with the new one
 // if it's present in the data gatherer's cache, (if the object isn't present, it gets added).
 // The cache key is the uid of the object
 func onUpdate(old, new interface{}, dgCache *cache.Cache) {
-	item := old.(*unstructured.Unstructured)
-	if metadata, ok := item.Object["metadata"]; ok {
-		data := metadata.(map[string]interface{})
-		if uid, ok := data["uid"]; ok {
-			cacheObject := updateCacheGatheredResource(uid.(string), new, dgCache)
-			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
-		} else {
-			log.Printf("could not %q resource %q to the cache, missing uid field", "update", data["name"].(string))
-		}
-	} else {
-		log.Printf("could not %q resource to the cache, missing metadata", "update")
+	item, ok := old.(cacheResource)
+	if ok {
+		cacheObject := updateCacheGatheredResource(string(item.GetUID()), new, dgCache)
+		dgCache.Set(string(item.GetUID()), cacheObject, cache.DefaultExpiration)
+		return
 	}
+
+	log.Printf("could not %q resource to the cache, missing metadata/uid field", "update")
 }
 
 // onDelete handles the informer deletion events, updating the object's properties with the deletion
 // time of the object (but not removing the object from the cache).
 // The cache key is the uid of the object
 func onDelete(obj interface{}, dgCache *cache.Cache) {
-	item := obj.(*unstructured.Unstructured)
-	if metadata, ok := item.Object["metadata"]; ok {
-		data := metadata.(map[string]interface{})
-		if uid, ok := data["uid"]; ok {
-			cacheObject := updateCacheGatheredResource(uid.(string), obj, dgCache)
-			cacheObject.DeletedAt = api.Time{Time: clock.now()}
-			dgCache.Set(uid.(string), cacheObject, cache.DefaultExpiration)
-		} else {
-			log.Printf("could not %q resource %q to the cache, missing uid field", "delete", data["name"].(string))
-		}
-	} else {
-		log.Printf("could not %q resource to the cache, missing metadata", "delete")
+	item, ok := obj.(cacheResource)
+	if ok {
+		cacheObject := updateCacheGatheredResource(string(item.GetUID()), obj, dgCache)
+		cacheObject.DeletedAt = api.Time{Time: clock.now()}
+		dgCache.Set(string(item.GetUID()), cacheObject, cache.DefaultExpiration)
+		return
 	}
+	log.Printf("could not %q resource to the cache, missing metadata/uid field", "delete")
 }
 
 // creates a new updated instance of a cache object, with the resource

--- a/pkg/datagatherer/k8s/client.go
+++ b/pkg/datagatherer/k8s/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -41,6 +42,22 @@ func NewDiscoveryClient(kubeconfigPath string) (discovery.DiscoveryClient, error
 	}
 
 	return *discoveryClient, nil
+}
+
+// NewClientSet creates a new kubernetes clientset using the provided kubeconfig.
+// If kubeconfigPath is not set/empty, it will attempt to load configuration using
+// the default loading rules.
+func NewClientSet(kubeconfigPath string) (kubernetes.Interface, error) {
+	var clientset *kubernetes.Clientset
+	cfg, err := loadRESTConfig(kubeconfigPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	clientset, err = kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return clientset, nil
 }
 
 func loadRESTConfig(path string) (*rest.Config, error) {

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -14,12 +14,17 @@ import (
 	"github.com/d4l3k/messagediff"
 	"github.com/jetstack/preflight/api"
 	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/diff"
 )
@@ -77,21 +82,35 @@ func getSecret(name, namespace string, data map[string]interface{}, isTLS bool, 
 func sortGatheredResources(list []*api.GatheredResource) {
 	if len(list) > 1 {
 		sort.SliceStable(list, func(i, j int) bool {
-			itemA := list[i].Resource.(*unstructured.Unstructured).GetName()
-			itemB := list[j].Resource.(*unstructured.Unstructured).GetName()
+			var itemA, itemB string
+			// unstructured
+			if item, ok := list[i].Resource.(*unstructured.Unstructured); ok {
+				itemA = item.GetName()
+			}
+			if item, ok := list[j].Resource.(*unstructured.Unstructured); ok {
+				itemB = item.GetName()
+			}
+
+			// pods
+			if item, ok := list[i].Resource.(*corev1.Pod); ok {
+				itemA = item.GetName()
+			}
+			if item, ok := list[j].Resource.(*corev1.Pod); ok {
+				itemB = item.GetName()
+			}
 			return itemA < itemB
 		})
 	}
 }
 
-func TestNewDataGathererWithClient(t *testing.T) {
+func TestNewDataGathererWithClientAndDynamicInformer(t *testing.T) {
 	ctx := context.Background()
 	config := ConfigDynamic{
 		IncludeNamespaces:    []string{"a"},
 		GroupVersionResource: schema.GroupVersionResource{Group: "foobar", Version: "v1", Resource: "foos"},
 	}
 	cl := fake.NewSimpleDynamicClient(runtime.NewScheme())
-	dg, err := config.newDataGathererWithClient(ctx, cl)
+	dg, err := config.newDataGathererWithClient(ctx, cl, nil)
 
 	if err != nil {
 		t.Errorf("expected no error but got: %v", err)
@@ -126,8 +145,60 @@ func TestNewDataGathererWithClient(t *testing.T) {
 	if gatherer.informer == nil {
 		t.Errorf("unexpected resource informer value: %v", nil)
 	}
-	if gatherer.sharedInformer == nil {
-		t.Errorf("unexpected sharedInformer value: %v", nil)
+	if gatherer.dynamicSharedInformer == nil {
+		t.Errorf("unexpected dynamicSharedInformer value: %v", nil)
+	}
+	if gatherer.nativeSharedInformer != nil {
+		t.Errorf("unexpected nativeSharedInformer value: %v. should be nil", gatherer.nativeSharedInformer)
+	}
+}
+
+func TestNewDataGathererWithClientAndSharedIndexInformer(t *testing.T) {
+	ctx := context.Background()
+	config := ConfigDynamic{
+		IncludeNamespaces:    []string{"a"},
+		GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+	}
+	clientset := fakeclientset.NewSimpleClientset()
+	dg, err := config.newDataGathererWithClient(ctx, nil, clientset)
+	if err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	}
+
+	expected := &DataGathererDynamic{
+		ctx:                  ctx,
+		k8sClientSet:         clientset,
+		groupVersionResource: config.GroupVersionResource,
+		// it's important that the namespaces are set as the IncludeNamespaces
+		// during initialization
+		namespaces: config.IncludeNamespaces,
+	}
+
+	gatherer := dg.(*DataGathererDynamic)
+	// test gatherer's fields
+	if !reflect.DeepEqual(gatherer.ctx, expected.ctx) {
+		t.Errorf("unexpected ctx difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if !reflect.DeepEqual(gatherer.k8sClientSet, expected.k8sClientSet) {
+		t.Errorf("unexpected client difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if !reflect.DeepEqual(gatherer.groupVersionResource, expected.groupVersionResource) {
+		t.Errorf("unexpected gvr difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if !reflect.DeepEqual(gatherer.namespaces, expected.namespaces) {
+		t.Errorf("unexpected namespace difference: %v", diff.ObjectDiff(dg, expected))
+	}
+	if gatherer.cache == nil {
+		t.Errorf("unexpected cache value: %v", nil)
+	}
+	if gatherer.informer == nil {
+		t.Errorf("unexpected resource informer value: %v", nil)
+	}
+	if gatherer.nativeSharedInformer == nil {
+		t.Errorf("unexpected nativeSharedInformer value: %v", nil)
+	}
+	if gatherer.dynamicSharedInformer != nil {
+		t.Errorf("unexpected dynamicSharedInformer value: %v. should be nil", gatherer.dynamicSharedInformer)
 	}
 }
 
@@ -498,15 +569,16 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			}
 			cl := fake.NewSimpleDynamicClientWithCustomListKinds(emptyScheme, gvrToListKind, tc.addObjects...)
 			// init the datagatherer's informer with the client
-			dg, err := tc.config.newDataGathererWithClient(ctx, cl)
+			dg, err := tc.config.newDataGathererWithClient(ctx, cl, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %+v", err)
 			}
 
-			// initializing test informer, this informer will capture all the events
-			// that occur in the test case and only allow the dg.Fetch to be perfomed
-			// after all the events have been triggered
-			factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(cl, 30*time.Second, metav1.NamespaceAll, nil)
+			// initializing test informer, this informer will update the waitGroup making sure all the
+			// update and delete events have all been capture by the informers, the 100 mills sleep is
+			// just to make sure dg informer is caught up. This allows us to wait until the waitGroup is
+			// done before doing the dg.Fetch.
+			factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(cl, 10*time.Minute, metav1.NamespaceAll, nil)
 			resourceInformer := factory.ForResource(tc.config.GroupVersionResource)
 			testInformer := resourceInformer.Informer()
 			testInformer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
@@ -534,7 +606,9 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 				t.Fatalf("unexpected client error: %+v", err)
 			}
 
-			// send resource events for the informer
+			// deletes all the objects set to be deleted, to trigger
+			// a delete event in the informers. Add 1 to wg making "sure" (https://github.com/kubernetes/kubernetes/issues/95372)
+			// the informers cache are sync
 			for ns, delete := range tc.deleteObjects {
 				wg.Add(1)
 				deletePolicy := metav1.DeletePropagationForeground
@@ -557,6 +631,295 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			}
 
 			// wait for all the events to occur, else timeut in 30 seconds
+			if waitTimeout(&wg, 30*time.Second) {
+				t.Fatalf("unexpected timeout")
+			}
+			res, err := dynamiDg.Fetch()
+			if err != nil && !tc.err {
+				t.Errorf("expected no error but got: %v", err)
+			}
+			if err == nil && tc.err {
+				t.Errorf("expected to get an error but didn't get one")
+			}
+
+			if tc.expected != nil {
+				items, ok := res.(map[string]interface{})
+				if !ok {
+					t.Errorf("expected result be an map[string]interface{} but wasn't")
+				}
+
+				list, ok := items["items"].([]*api.GatheredResource)
+				if !ok {
+					t.Errorf("expected result be an []*api.GatheredResource but wasn't")
+				}
+				// sorting list of results by name
+				sortGatheredResources(list)
+				// sorting list of expected results by name
+				sortGatheredResources(tc.expected)
+
+				if diff, equal := messagediff.PrettyDiff(tc.expected, list); !equal {
+					t.Errorf("\n%s", diff)
+					expectedJSON, _ := json.MarshalIndent(tc.expected, "", "  ")
+					gotJSON, _ := json.MarshalIndent(list, "", "  ")
+					t.Fatalf("unexpected JSON: \ngot \n%s\nwant\n%s", string(gotJSON), expectedJSON)
+				}
+			}
+		})
+	}
+}
+
+func TestDynamicGathererNativeResources_Fetch(t *testing.T) {
+	// start a k8s client
+	// init the datagatherer's informer with the client
+	// add/delete resources watched by the data gatherer
+	// check the expected result
+	podGVR := schema.GroupVersionResource{Group: corev1.SchemeGroupVersion.Group, Version: corev1.SchemeGroupVersion.Version, Resource: "pods"}
+	tests := map[string]struct {
+		config        ConfigDynamic
+		addObjects    []runtime.Object
+		deleteObjects map[string]string
+		updateObjects map[string]runtime.Object
+		expected      []*api.GatheredResource
+		err           bool
+	}{
+		"only a Pod should be returned if GVR selects pods": {
+			addObjects: []runtime.Object{
+				getObject("foobar/v1", "Foo", "testfoo", "testns", false),
+				getObject("v1", "Service", "testservice", "testns", false),
+				getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns", UID: "uid-testpod1"}},
+			},
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{"testns"},
+				GroupVersionResource: podGVR,
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns", UID: "uid-testpod1"}},
+				},
+			},
+		},
+		"delete a Pod resource from the testns, the cache should have a Pod with deletedAt set to now()": {
+			addObjects: []runtime.Object{
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testfoo", Namespace: "testns", UID: "uid-testfoo1"}},
+				getObject("v1", "Service", "testservice", "testns", false),
+				getObject("foobar/v1", "NotFoo", "notfoo", "testns", false),
+			},
+			deleteObjects: map[string]string{
+				"testns": "testfoo",
+			},
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{"testns"},
+				GroupVersionResource: podGVR,
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource:  &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testfoo", Namespace: "testns", UID: "uid-testfoo1"}},
+					DeletedAt: api.Time{Time: clock.now()},
+				},
+			},
+		},
+		"Pods in different namespaces should be returned if no namespace field is set": {
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{""},
+				GroupVersionResource: podGVR,
+			},
+			addObjects: []runtime.Object{
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns", UID: "uid-testpod1"}},
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2"}},
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns", UID: "uid-testpod1"}},
+				},
+				{
+					Resource: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2"}},
+				},
+			},
+		},
+		"Delete Pods in different namespaces should be returned if no namespace field is set": {
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{""},
+				GroupVersionResource: podGVR,
+			},
+			addObjects: []runtime.Object{
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns", UID: "uid-testpod1"}},
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2"}},
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns", UID: "uid-testpod1"}},
+				},
+				{
+					Resource: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2"}},
+				},
+			},
+		},
+		"Delete all Pod resources, all the fetched resources should have a deletedAt field set to now()": {
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{""},
+				GroupVersionResource: podGVR,
+			},
+			deleteObjects: map[string]string{
+				"testns1": "testpod1",
+				"testns2": "testpod2",
+			},
+			addObjects: []runtime.Object{
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns1", UID: "uid-testpod1"}},
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2"}},
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource:  &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns1", UID: "uid-testpod1"}},
+					DeletedAt: api.Time{Time: clock.now()},
+				},
+				{
+					Resource:  &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2"}},
+					DeletedAt: api.Time{Time: clock.now()},
+				},
+			},
+		},
+		"Update all Pods resources, all the fetched resources should have been updated": {
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{""},
+				GroupVersionResource: podGVR,
+			},
+			updateObjects: map[string]runtime.Object{
+				"testns1": &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns1", UID: "uid-testpod1", Labels: map[string]string{"foo": "newlabel"}}},
+				"testns2": &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2", Labels: map[string]string{"foo": "newlabel"}}},
+			},
+			addObjects: []runtime.Object{
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns1", UID: "uid-testpod1"}},
+				&corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2"}},
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod1", Namespace: "testns1", UID: "uid-testpod1", Labels: map[string]string{"foo": "newlabel"}}},
+				},
+				{
+					Resource: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "testpod2", Namespace: "testns2", UID: "uid-testpod2", Labels: map[string]string{"foo": "newlabel"}}},
+				},
+			},
+		},
+		"only Pods in the specified namespace should be returned": {
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{"testns"},
+				GroupVersionResource: podGVR,
+			},
+			addObjects: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testfoo1",
+						Namespace: "testns",
+						UID:       "uid-testfoo1",
+					},
+				},
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testfoo1",
+						Namespace: "nottestns",
+						UID:       "uid-testfoo2",
+					},
+				},
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource: &corev1.Pod{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Pod",
+							APIVersion: "v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testfoo1",
+							Namespace: "testns",
+							UID:       "uid-testfoo1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var wg sync.WaitGroup
+			ctx := context.Background()
+
+			var clientset kubernetes.Interface
+			clientset = fakeclientset.NewSimpleClientset(tc.addObjects...)
+
+			// init the datagatherer's informer with the client
+			dg, err := tc.config.newDataGathererWithClient(ctx, nil, clientset)
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+
+			// initializing test informer, this informer will capture all the events
+			// that occur in the test case and only allow the dg.Fetch to be performed
+			// after all the events have been triggered
+			factory := informers.NewSharedInformerFactoryWithOptions(clientset,
+				10*time.Minute,
+				informers.WithNamespace(metav1.NamespaceAll),
+				informers.WithTweakListOptions(func(options *metav1.ListOptions) {}))
+			testInformer := factory.Core().V1().Pods().Informer()
+			testInformer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
+				DeleteFunc: func(obj interface{}) {
+					defer wg.Done()
+					time.Sleep(100 * time.Millisecond)
+				},
+				UpdateFunc: func(old, new interface{}) {
+					defer wg.Done()
+					time.Sleep(100 * time.Millisecond)
+				},
+			})
+
+			//start test Informer
+			factory.Start(ctx.Done())
+			k8scache.WaitForCacheSync(ctx.Done(), testInformer.HasSynced)
+
+			// start data gatherer informer
+			dynamiDg := dg
+			err = dynamiDg.Run(ctx.Done())
+			if err != nil {
+				t.Fatalf("unexpected client error: %+v", err)
+			}
+			err = dynamiDg.WaitForCacheSync(ctx.Done())
+			if err != nil {
+				t.Fatalf("unexpected client error: %+v", err)
+			}
+
+			// deletes all the objects set to be deleted, to trigger
+			// a delete event in the informers. Add 1 to wg
+			for ns, delete := range tc.deleteObjects {
+				wg.Add(1)
+				deletePolicy := metav1.DeletePropagationForeground
+				deleteOptions := metav1.DeleteOptions{
+					PropagationPolicy: &deletePolicy,
+				}
+				err := clientset.CoreV1().Pods(ns).Delete(ctx, delete, deleteOptions)
+				if err != nil {
+					t.Fatalf("unexpected client delete error: %+v", err)
+				}
+			}
+
+			for ns, update := range tc.updateObjects {
+				wg.Add(1)
+				new := update.(*corev1.Pod)
+				_, err := clientset.CoreV1().Pods(ns).Update(ctx, new, metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatalf("unexpected client update error: %+v", err)
+				}
+			}
+
+			// wait for all the events to occur, else timeout in 30 seconds
 			if waitTimeout(&wg, 5*time.Second) {
 				t.Fatalf("unexpected timeout")
 			}

--- a/pkg/datagatherer/versionchecker/fixtures/nodes.json
+++ b/pkg/datagatherer/versionchecker/fixtures/nodes.json
@@ -1,6 +1,6 @@
 {
     "apiVersion": "v1",
-    "kind": "List",
+    "kind": "NodeList",
     "metadata": {
       "resourceVersion": "",
       "selfLink": ""

--- a/pkg/datagatherer/versionchecker/fixtures/pods.json.tmpl
+++ b/pkg/datagatherer/versionchecker/fixtures/pods.json.tmpl
@@ -1,6 +1,6 @@
 {
   "apiVersion": "v1",
-  "kind": "List",
+  "kind": "PodList",
   "metadata": {
     "resourceVersion": "",
     "selfLink": ""

--- a/pkg/datagatherer/versionchecker/versionchecker_test.go
+++ b/pkg/datagatherer/versionchecker/versionchecker_test.go
@@ -400,7 +400,7 @@ func createLocalTestServer(t *testing.T) *httptest.Server {
 		default:
 			t.Fatalf("Unexpected URL was called: %s", r.URL.Path)
 		}
-
+		w.Header().Set("Content-Type", "application/json")
 		w.Write(responseContent)
 	}))
 


### PR DESCRIPTION
The k8s/dynamic is now going to use a sharedinformer for k8s native
v1 resources, instead of using a dynamicinformer. This reduceses the
current memory usage by about 25MB.

Before the refactoring, the memory usage was around ~117MB https://github.com/jetstack/jetstack-secure/pull/306

**After refactoring** the average memory usage is ~92MB
![image](https://user-images.githubusercontent.com/16049411/161232793-12c1919c-2a62-4081-9eeb-712d397efe40.png)

**After refactoring profiling**
![out-new-refactoring-openshift-VI-all](https://user-images.githubusercontent.com/16049411/161234368-b4c094cf-c82b-470f-a40c-bace33d68580.png)



Signed-off-by: Oluwole Fadeyi <oluwole.fadeyi@jetstack.io>