### PR TITLE
feat: Adding licensing information to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static as release
 
 # TARGETPLATFORM comes from the buildx context and it will be something like `linux/arm64/v8` or `linux/amd64`.
 # Ref: https://docs.docker.com/buildx/working-with-buildx/
@@ -7,6 +7,10 @@ ARG TARGETPLATFORM
 USER 1000:1000
 
 COPY ./builds/${TARGETPLATFORM}/preflight /bin/preflight
+
+# '/usr/share/doc/$PACKAGE' is a pretty standard location for notices. In particular Debian does it this way.
+COPY ./builds/licenses /usr/share/doc/preflight/
+
 # load in an example config file
 ADD ./agent.yaml /etc/preflight/agent.yaml
 ENTRYPOINT ["preflight"]

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -21,3 +21,11 @@ RUN make build-all-platforms \
     OAUTH_CLIENT_ID=${oauth_client_id} \
     OAUTH_CLIENT_SECRET=${oauth_client_secret} \
     OAUTH_AUTH_SERVER_DOMAIN=${oauth_auth_server_domain}
+
+
+# c781b427440f8ea100841eefdd308e660d26d121 is the v1.0.0 tag at the time of writing. 
+RUN go install github.com/google/go-licenses@c781b427440f8ea100841eefdd308e660d26d121
+
+# We need this '|| true' because go-licenses could fail to find a license so
+# may return a non-zero exit code and there's no way to supress it.
+RUN /go/bin/go-licenses save ./ --save_path="./builds/licenses/" || true


### PR DESCRIPTION
Using [go-licenses](https://github.com/google/go-licenses) to pull in the licensing for all go dependencies. The release image then hosts all licencing information under: "/usr/share/doc/preflight".

Tried to implement in a manner that fitted best with the Makefile / Dockerfile hybrid solution going on.

Thanks to @JamesLaverack for going through this with me. After building locally we extracted the image and inspected the contents, here's an example output for reference:

```
usr/
usr/share/
usr/share/doc/
usr/share/doc/preflight/
usr/share/doc/preflight/cloud.google.com/
usr/share/doc/preflight/cloud.google.com/go/
usr/share/doc/preflight/cloud.google.com/go/compute/
usr/share/doc/preflight/cloud.google.com/go/compute/metadata/
usr/share/doc/preflight/cloud.google.com/go/compute/metadata/LICENSE
usr/share/doc/preflight/github.com/
usr/share/doc/preflight/github.com/Azure/
usr/share/doc/preflight/github.com/Azure/aks-engine/
usr/share/doc/preflight/github.com/Azure/aks-engine/pkg/
usr/share/doc/preflight/github.com/Azure/aks-engine/pkg/api/
usr/share/doc/preflight/github.com/Azure/aks-engine/pkg/api/LICENSE
usr/share/doc/preflight/github.com/Azure/go-autorest/
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/LICENSE
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/adal/
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/adal/LICENSE
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/date/
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/date/LICENSE
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/to/
usr/share/doc/preflight/github.com/Azure/go-autorest/autorest/to/LICENSE
usr/share/doc/preflight/github.com/Azure/go-autorest/logger/
usr/share/doc/preflight/github.com/Azure/go-autorest/logger/LICENSE
usr/share/doc/preflight/github.com/Azure/go-autorest/tracing/
usr/share/doc/preflight/github.com/Azure/go-autorest/tracing/LICENSE
usr/share/doc/preflight/github.com/BurntSushi/
usr/share/doc/preflight/github.com/BurntSushi/toml/
usr/share/doc/preflight/github.com/BurntSushi/toml/COPYING
usr/share/doc/preflight/github.com/Jeffail/
usr/share/doc/preflight/github.com/Jeffail/gabs/
usr/share/doc/preflight/github.com/Jeffail/gabs/v2/
usr/share/doc/preflight/github.com/Jeffail/gabs/v2/LICENSE
usr/share/doc/preflight/github.com/aws/
usr/share/doc/preflight/github.com/aws/aws-sdk-go/
usr/share/doc/preflight/github.com/aws/aws-sdk-go/LICENSE.txt
usr/share/doc/preflight/github.com/aws/aws-sdk-go/NOTICE.txt
usr/share/doc/preflight/github.com/aws/aws-sdk-go/internal/
usr/share/doc/preflight/github.com/aws/aws-sdk-go/internal/sync/
usr/share/doc/preflight/github.com/aws/aws-sdk-go/internal/sync/singleflight/
usr/share/doc/preflight/github.com/aws/aws-sdk-go/internal/sync/singleflight/LICENSE
usr/share/doc/preflight/github.com/beorn7/
usr/share/doc/preflight/github.com/beorn7/perks/
usr/share/doc/preflight/github.com/beorn7/perks/quantile/
usr/share/doc/preflight/github.com/beorn7/perks/quantile/LICENSE
usr/share/doc/preflight/github.com/blang/
usr/share/doc/preflight/github.com/blang/semver/
usr/share/doc/preflight/github.com/blang/semver/LICENSE
usr/share/doc/preflight/github.com/cenkalti/
usr/share/doc/preflight/github.com/cenkalti/backoff/
usr/share/doc/preflight/github.com/cenkalti/backoff/LICENSE
usr/share/doc/preflight/github.com/cespare/
usr/share/doc/preflight/github.com/cespare/xxhash/
usr/share/doc/preflight/github.com/cespare/xxhash/v2/
usr/share/doc/preflight/github.com/cespare/xxhash/v2/LICENSE.txt
usr/share/doc/preflight/github.com/davecgh/
usr/share/doc/preflight/github.com/davecgh/go-spew/
usr/share/doc/preflight/github.com/davecgh/go-spew/spew/
usr/share/doc/preflight/github.com/davecgh/go-spew/spew/LICENSE
usr/share/doc/preflight/github.com/dgrijalva/
usr/share/doc/preflight/github.com/dgrijalva/jwt-go/
usr/share/doc/preflight/github.com/dgrijalva/jwt-go/LICENSE
usr/share/doc/preflight/github.com/fatih/
usr/share/doc/preflight/github.com/fatih/color/
usr/share/doc/preflight/github.com/fatih/color/LICENSE.md
usr/share/doc/preflight/github.com/form3tech-oss/
usr/share/doc/preflight/github.com/form3tech-oss/jwt-go/
usr/share/doc/preflight/github.com/form3tech-oss/jwt-go/LICENSE
usr/share/doc/preflight/github.com/go-logr/
usr/share/doc/preflight/github.com/go-logr/logr/
usr/share/doc/preflight/github.com/go-logr/logr/LICENSE
usr/share/doc/preflight/github.com/go-playground/
usr/share/doc/preflight/github.com/go-playground/locales/
usr/share/doc/preflight/github.com/go-playground/locales/LICENSE
usr/share/doc/preflight/github.com/go-playground/universal-translator/
usr/share/doc/preflight/github.com/go-playground/universal-translator/LICENSE
usr/share/doc/preflight/github.com/gogo/
usr/share/doc/preflight/github.com/gogo/protobuf/
usr/share/doc/preflight/github.com/gogo/protobuf/LICENSE
usr/share/doc/preflight/github.com/golang/
usr/share/doc/preflight/github.com/golang/groupcache/
usr/share/doc/preflight/github.com/golang/groupcache/lru/
usr/share/doc/preflight/github.com/golang/groupcache/lru/LICENSE
usr/share/doc/preflight/github.com/golang/protobuf/
usr/share/doc/preflight/github.com/golang/protobuf/LICENSE
usr/share/doc/preflight/github.com/google/
usr/share/doc/preflight/github.com/google/go-cmp/
usr/share/doc/preflight/github.com/google/go-cmp/cmp/
usr/share/doc/preflight/github.com/google/go-cmp/cmp/LICENSE
usr/share/doc/preflight/github.com/google/gofuzz/
usr/share/doc/preflight/github.com/google/gofuzz/LICENSE
usr/share/doc/preflight/github.com/googleapis/
usr/share/doc/preflight/github.com/googleapis/gax-go/
usr/share/doc/preflight/github.com/googleapis/gax-go/v2/
usr/share/doc/preflight/github.com/googleapis/gax-go/v2/LICENSE
usr/share/doc/preflight/github.com/googleapis/gnostic/
usr/share/doc/preflight/github.com/googleapis/gnostic/LICENSE
usr/share/doc/preflight/github.com/hashicorp/
usr/share/doc/preflight/github.com/hashicorp/errwrap/
usr/share/doc/preflight/github.com/hashicorp/errwrap/LICENSE
usr/share/doc/preflight/github.com/hashicorp/errwrap/README.md
usr/share/doc/preflight/github.com/hashicorp/errwrap/errwrap.go
usr/share/doc/preflight/github.com/hashicorp/errwrap/errwrap_test.go
usr/share/doc/preflight/github.com/hashicorp/errwrap/go.mod
usr/share/doc/preflight/github.com/hashicorp/go-multierror/
usr/share/doc/preflight/github.com/hashicorp/go-multierror/.circleci/
usr/share/doc/preflight/github.com/hashicorp/go-multierror/.circleci/config.yml
usr/share/doc/preflight/github.com/hashicorp/go-multierror/LICENSE
usr/share/doc/preflight/github.com/hashicorp/go-multierror/Makefile
usr/share/doc/preflight/github.com/hashicorp/go-multierror/README.md
usr/share/doc/preflight/github.com/hashicorp/go-multierror/append.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/append_test.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/flatten.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/flatten_test.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/format.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/format_test.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/go.mod
usr/share/doc/preflight/github.com/hashicorp/go-multierror/go.sum
usr/share/doc/preflight/github.com/hashicorp/go-multierror/group.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/group_test.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/multierror.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/multierror_test.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/prefix.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/prefix_test.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/sort.go
usr/share/doc/preflight/github.com/hashicorp/go-multierror/sort_test.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/
usr/share/doc/preflight/github.com/hashicorp/golang-lru/.gitignore
usr/share/doc/preflight/github.com/hashicorp/golang-lru/2q.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/2q_test.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/LICENSE
usr/share/doc/preflight/github.com/hashicorp/golang-lru/README.md
usr/share/doc/preflight/github.com/hashicorp/golang-lru/arc.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/arc_test.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/doc.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/go.mod
usr/share/doc/preflight/github.com/hashicorp/golang-lru/lru.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/lru_test.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/simplelru/
usr/share/doc/preflight/github.com/hashicorp/golang-lru/simplelru/lru.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
usr/share/doc/preflight/github.com/hashicorp/golang-lru/simplelru/lru_test.go
usr/share/doc/preflight/github.com/imdario/
usr/share/doc/preflight/github.com/imdario/mergo/
usr/share/doc/preflight/github.com/imdario/mergo/LICENSE
usr/share/doc/preflight/github.com/jetstack/
usr/share/doc/preflight/github.com/jetstack/preflight/
usr/share/doc/preflight/github.com/jetstack/preflight/LICENSE
usr/share/doc/preflight/github.com/jetstack/version-checker/
usr/share/doc/preflight/github.com/jetstack/version-checker/pkg/
usr/share/doc/preflight/github.com/jetstack/version-checker/pkg/LICENSE
usr/share/doc/preflight/github.com/jmespath/
usr/share/doc/preflight/github.com/jmespath/go-jmespath/
usr/share/doc/preflight/github.com/jmespath/go-jmespath/LICENSE
usr/share/doc/preflight/github.com/json-iterator/
usr/share/doc/preflight/github.com/json-iterator/go/
usr/share/doc/preflight/github.com/json-iterator/go/LICENSE
usr/share/doc/preflight/github.com/juju/
usr/share/doc/preflight/github.com/juju/errors/
usr/share/doc/preflight/github.com/juju/errors/.gitignore
usr/share/doc/preflight/github.com/juju/errors/LICENSE
usr/share/doc/preflight/github.com/juju/errors/Makefile
usr/share/doc/preflight/github.com/juju/errors/README.md
usr/share/doc/preflight/github.com/juju/errors/dependencies.tsv
usr/share/doc/preflight/github.com/juju/errors/doc.go
usr/share/doc/preflight/github.com/juju/errors/error.go
usr/share/doc/preflight/github.com/juju/errors/error_test.go
usr/share/doc/preflight/github.com/juju/errors/errortypes.go
usr/share/doc/preflight/github.com/juju/errors/errortypes_test.go
usr/share/doc/preflight/github.com/juju/errors/example_test.go
usr/share/doc/preflight/github.com/juju/errors/export_test.go
usr/share/doc/preflight/github.com/juju/errors/functions.go
usr/share/doc/preflight/github.com/juju/errors/functions_test.go
usr/share/doc/preflight/github.com/juju/errors/package_test.go
usr/share/doc/preflight/github.com/juju/errors/path.go
usr/share/doc/preflight/github.com/juju/errors/path_test.go
usr/share/doc/preflight/github.com/leodido/
usr/share/doc/preflight/github.com/leodido/go-urn/
usr/share/doc/preflight/github.com/leodido/go-urn/LICENSE
usr/share/doc/preflight/github.com/mattn/
usr/share/doc/preflight/github.com/mattn/go-colorable/
usr/share/doc/preflight/github.com/mattn/go-colorable/LICENSE
usr/share/doc/preflight/github.com/mattn/go-isatty/
usr/share/doc/preflight/github.com/mattn/go-isatty/LICENSE
usr/share/doc/preflight/github.com/matttproud/
usr/share/doc/preflight/github.com/matttproud/golang_protobuf_extensions/
usr/share/doc/preflight/github.com/matttproud/golang_protobuf_extensions/pbutil/
usr/share/doc/preflight/github.com/matttproud/golang_protobuf_extensions/pbutil/LICENSE
usr/share/doc/preflight/github.com/matttproud/golang_protobuf_extensions/pbutil/NOTICE
usr/share/doc/preflight/github.com/modern-go/
usr/share/doc/preflight/github.com/modern-go/concurrent/
usr/share/doc/preflight/github.com/modern-go/concurrent/LICENSE
usr/share/doc/preflight/github.com/modern-go/reflect2/
usr/share/doc/preflight/github.com/modern-go/reflect2/LICENSE
usr/share/doc/preflight/github.com/pkg/
usr/share/doc/preflight/github.com/pkg/errors/
usr/share/doc/preflight/github.com/pkg/errors/LICENSE
usr/share/doc/preflight/github.com/pmylund/
usr/share/doc/preflight/github.com/pmylund/go-cache/
usr/share/doc/preflight/github.com/pmylund/go-cache/LICENSE
usr/share/doc/preflight/github.com/prometheus/
usr/share/doc/preflight/github.com/prometheus/client_golang/
usr/share/doc/preflight/github.com/prometheus/client_golang/prometheus/
usr/share/doc/preflight/github.com/prometheus/client_golang/prometheus/LICENSE
usr/share/doc/preflight/github.com/prometheus/client_golang/prometheus/NOTICE
usr/share/doc/preflight/github.com/prometheus/client_model/
usr/share/doc/preflight/github.com/prometheus/client_model/go/
usr/share/doc/preflight/github.com/prometheus/client_model/go/LICENSE
usr/share/doc/preflight/github.com/prometheus/client_model/go/NOTICE
usr/share/doc/preflight/github.com/prometheus/common/
usr/share/doc/preflight/github.com/prometheus/common/LICENSE
usr/share/doc/preflight/github.com/prometheus/common/NOTICE
usr/share/doc/preflight/github.com/prometheus/common/internal/
usr/share/doc/preflight/github.com/prometheus/common/internal/bitbucket.org/
usr/share/doc/preflight/github.com/prometheus/common/internal/bitbucket.org/ww/
usr/share/doc/preflight/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/
usr/share/doc/preflight/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/README.txt
usr/share/doc/preflight/github.com/prometheus/procfs/
usr/share/doc/preflight/github.com/prometheus/procfs/LICENSE
usr/share/doc/preflight/github.com/prometheus/procfs/NOTICE
usr/share/doc/preflight/github.com/sirupsen/
usr/share/doc/preflight/github.com/sirupsen/logrus/
usr/share/doc/preflight/github.com/sirupsen/logrus/LICENSE
usr/share/doc/preflight/github.com/spf13/
usr/share/doc/preflight/github.com/spf13/cobra/
usr/share/doc/preflight/github.com/spf13/cobra/LICENSE.txt
usr/share/doc/preflight/github.com/spf13/pflag/
usr/share/doc/preflight/github.com/spf13/pflag/LICENSE
usr/share/doc/preflight/go.opencensus.io/
usr/share/doc/preflight/go.opencensus.io/LICENSE
usr/share/doc/preflight/golang.org/
usr/share/doc/preflight/golang.org/x/
usr/share/doc/preflight/golang.org/x/crypto/
usr/share/doc/preflight/golang.org/x/crypto/LICENSE
usr/share/doc/preflight/golang.org/x/net/
usr/share/doc/preflight/golang.org/x/net/LICENSE
usr/share/doc/preflight/golang.org/x/oauth2/
usr/share/doc/preflight/golang.org/x/oauth2/LICENSE
usr/share/doc/preflight/golang.org/x/sys/
usr/share/doc/preflight/golang.org/x/sys/LICENSE
usr/share/doc/preflight/golang.org/x/term/
usr/share/doc/preflight/golang.org/x/term/LICENSE
usr/share/doc/preflight/golang.org/x/text/
usr/share/doc/preflight/golang.org/x/text/LICENSE
usr/share/doc/preflight/golang.org/x/time/
usr/share/doc/preflight/golang.org/x/time/rate/
usr/share/doc/preflight/golang.org/x/time/rate/LICENSE
usr/share/doc/preflight/google.golang.org/
usr/share/doc/preflight/google.golang.org/api/
usr/share/doc/preflight/google.golang.org/api/LICENSE
usr/share/doc/preflight/google.golang.org/api/internal/
usr/share/doc/preflight/google.golang.org/api/internal/third_party/
usr/share/doc/preflight/google.golang.org/api/internal/third_party/uritemplates/
usr/share/doc/preflight/google.golang.org/api/internal/third_party/uritemplates/LICENSE
usr/share/doc/preflight/google.golang.org/genproto/
usr/share/doc/preflight/google.golang.org/genproto/googleapis/
usr/share/doc/preflight/google.golang.org/genproto/googleapis/rpc/
usr/share/doc/preflight/google.golang.org/genproto/googleapis/rpc/status/
usr/share/doc/preflight/google.golang.org/genproto/googleapis/rpc/status/LICENSE
usr/share/doc/preflight/google.golang.org/grpc/
usr/share/doc/preflight/google.golang.org/grpc/LICENSE
usr/share/doc/preflight/google.golang.org/protobuf/
usr/share/doc/preflight/google.golang.org/protobuf/LICENSE
usr/share/doc/preflight/gopkg.in/
usr/share/doc/preflight/gopkg.in/go-playground/
usr/share/doc/preflight/gopkg.in/go-playground/validator.v9/
usr/share/doc/preflight/gopkg.in/go-playground/validator.v9/LICENSE
usr/share/doc/preflight/gopkg.in/inf.v0/
usr/share/doc/preflight/gopkg.in/inf.v0/LICENSE
usr/share/doc/preflight/gopkg.in/yaml.v2/
usr/share/doc/preflight/gopkg.in/yaml.v2/LICENSE
usr/share/doc/preflight/gopkg.in/yaml.v2/NOTICE
usr/share/doc/preflight/gopkg.in/yaml.v3/
usr/share/doc/preflight/gopkg.in/yaml.v3/LICENSE
usr/share/doc/preflight/gopkg.in/yaml.v3/NOTICE
usr/share/doc/preflight/k8s.io/
usr/share/doc/preflight/k8s.io/api/
usr/share/doc/preflight/k8s.io/api/LICENSE
usr/share/doc/preflight/k8s.io/apimachinery/
usr/share/doc/preflight/k8s.io/apimachinery/LICENSE
usr/share/doc/preflight/k8s.io/client-go/
usr/share/doc/preflight/k8s.io/client-go/LICENSE
usr/share/doc/preflight/k8s.io/klog/
usr/share/doc/preflight/k8s.io/klog/v2/
usr/share/doc/preflight/k8s.io/klog/v2/LICENSE
usr/share/doc/preflight/k8s.io/utils/
usr/share/doc/preflight/k8s.io/utils/LICENSE
usr/share/doc/preflight/sigs.k8s.io/
usr/share/doc/preflight/sigs.k8s.io/structured-merge-diff/
usr/share/doc/preflight/sigs.k8s.io/structured-merge-diff/v4/
usr/share/doc/preflight/sigs.k8s.io/structured-merge-diff/v4/value/
usr/share/doc/preflight/sigs.k8s.io/structured-merge-diff/v4/value/LICENSE
usr/share/doc/preflight/sigs.k8s.io/yaml/
usr/share/doc/preflight/sigs.k8s.io/yaml/LICENSE
```