### PR TITLE
Add datareadings size prom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ sends:
 ```bash
 go run main.go echo
 ```
+
+## Metrics
+
+The Jetstack-Secure agent exposes its metrics through a Prometheus server, on port 8081.
+The Prometheus server is disabled by default but can be enabled by passing the `--enable-metrics` flag to the agent binary.

--- a/pkg/agent/metrics.go
+++ b/pkg/agent/metrics.go
@@ -1,0 +1,15 @@
+package agent
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricPayloadSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "jscp",
+			Subsystem: "agent",
+			Name:      "data_readings_upload_size",
+			Help:      "Data readings upload size (in bytes) sent by the jscp in-cluster agent.",
+		}, []string{"organization", "cluster"})
+)


### PR DESCRIPTION
Adds a prom gauge metrics for the datareadings upload size.

Signed-off-by: Oluwole Fadeyi <oluwole.fadeyi@jetstack.io>