### PR TITLE
Update cosign

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -50,9 +50,9 @@ jobs:
       # See issue https://github.com/actions/checkout/issues/760
       run: git config --global --add safe.directory $GITHUB_WORKSPACE
     - name: Install cosign
-      uses: sigstore/cosign-installer@9e9de2292db7abb3f51b7f4808d98f0d347a8919
+      uses: sigstore/cosign-installer@v3.0.2
       with:
-        cosign-release: v1.5.2
+        cosign-release: v2.0.2
     - name: Install Syft
       uses: anchore/sbom-action/download-syft@422cb34a0f8b599678c41b21163ea6088edb2624
     - uses: actions/checkout@v3


### PR DESCRIPTION
It seems the pipeline is failing because we are using an old cosign version. This updates cosign-installer and cosign itself to the latest version.