### PR TITLE
Do not add '-y' in cosign attach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ sign-docker-image:
 .PHONY: sbom-docker-image
 sbom-docker-image:
 	@syft $(DOCKER_IMAGE):$(VERSION) -o cyclonedx > bom.xml
-	@cosign attach sbom -y --sbom bom.xml --type cyclonedx $(DOCKER_IMAGE):$(VERSION)
+	@cosign attach sbom --sbom bom.xml --type cyclonedx $(DOCKER_IMAGE):$(VERSION)
 	@cosign sign -y --attachment sbom $(DOCKER_IMAGE):$(VERSION)
 
 .PHONY: attest-docker-image


### PR DESCRIPTION
We added `-y` to `cosign attach` but we shouldn't do that.

https://github.com/jetstack/jetstack-secure/actions/runs/4797009114/jobs/8533454381

```
Run make sbom-docker-image
  
Error: unknown shorthand flag: 'y' in -y
main.go:74: error during command execution: unknown shorthand flag: 'y' in -y
make: *** [Makefile:116: sbom-docker-image] Error 1
```