### PR TITLE
TLS Protect Cloud Authentication Addition

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -11,3 +11,7 @@ data-gatherers:
     name: "dummy-fail"
     config:
       always-fail: true
+venafi-cloud:
+  upload_id: "example-id"
+  upload_path: "/example/endpoint/path"
+  

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -77,11 +77,11 @@ func init() {
 		"Location of the credentials file. For OAuth2 based authentication.",
 	)
 	agentCmd.PersistentFlags().StringVarP(
-		&agent.TLSProtectCloudCredentialsPath,
-		"tls-protect-cloud-credentials-file",
-		"t",
+		&agent.VenafiSvcAccountCredentialsPath,
+		"venafi-svc-account-credentials-file",
 		"",
-		"Location of the TLS Protect Cloud credentials file. For TLS Protect Cloud based authentication.",
+		"",
+		"Location of the Venafi Cloud service account credentials file. For Venafi Cloud service account based authentication.",
 	)
 	agentCmd.PersistentFlags().BoolVarP(
 		&agent.OneShot,

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -76,12 +76,12 @@ func init() {
 		"",
 		"Location of the credentials file. For OAuth2 based authentication.",
 	)
-	agentCmd.PersistentFlags().StringVarP(
-		&agent.VenafiSvcAccountCredentialsPath,
-		"venafi-svc-account-credentials-file",
+	agentCmd.PersistentFlags().BoolVarP(
+		&agent.VenafiCloudMode,
+		"venafi-cloud",
 		"",
-		"",
-		"Location of the Venafi Cloud service account credentials file. For Venafi Cloud service account based authentication.",
+		false,
+		"Runs agent with parsing config and credentials file in Venafi Cloud format if true.",
 	)
 	agentCmd.PersistentFlags().BoolVarP(
 		&agent.OneShot,

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -76,6 +76,13 @@ func init() {
 		"",
 		"Location of the credentials file. For OAuth2 based authentication.",
 	)
+	agentCmd.PersistentFlags().StringVarP(
+		&agent.TLSProtectCloudCredentialsPath,
+		"tls-protect-cloud-credentials-file",
+		"t",
+		"",
+		"Location of the TLS Protect Cloud credentials file. For TLS Protect Cloud based authentication.",
+	)
 	agentCmd.PersistentFlags().BoolVarP(
 		&agent.OneShot,
 		"one-shot",

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,6 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/d4l3k/messagediff v1.2.1
 	github.com/fatih/color v1.15.0
-	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/json-iterator/go v1.1.12
@@ -68,7 +66,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/d4l3k/messagediff v1.2.1
 	github.com/fatih/color v1.15.0
+	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
+	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/json-iterator/go v1.1.12
 	github.com/juju/errors v1.0.0
@@ -36,11 +39,11 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
-github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
-github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -55,8 +53,6 @@ github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrK
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
+github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
+github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -53,6 +55,10 @@ github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrK
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jetstack/preflight/pkg/datagatherer/k8s"
 	"github.com/jetstack/preflight/pkg/datagatherer/local"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Config wraps the options for a run of the agent.

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -48,9 +48,9 @@ type DataGatherer struct {
 }
 
 type VenafiCloudConfig struct {
-	// UploadID is the upload ID that will be used when
+	// UploaderID is the upload ID that will be used when
 	// creating a cluster connection
-	UploadID string `yaml:"upload_id,omitempty"`
+	UploaderID string `yaml:"uploader_id,omitempty"`
 	// UploadPath is the endpoint path for the upload API.
 	UploadPath string `yaml:"upload_path,omitempty"`
 }
@@ -131,7 +131,7 @@ func (c *Config) validate() error {
 
 	// configured for Venafi Cloud
 	if c.VenafiCloud != nil {
-		if c.VenafiCloud.UploadID == "" {
+		if c.VenafiCloud.UploaderID == "" {
 			result = multierror.Append(result, fmt.Errorf("upload_id is required in Venafi Cloud mode"))
 		}
 		if c.VenafiCloud.UploadPath == "" {

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -30,12 +30,8 @@ type Config struct {
 	// InputPath replaces DataGatherers with input data file
 	InputPath string `yaml:"input-path"`
 	// OutputPath replaces Server with output data file
-	OutputPath string `yaml:"output-path"`
-	// TLSProtectCloudkUploadID is the upload ID that will be used when
-	// creating a cluster connection
-	TLSProtectCloudkUploadID string `yaml:"upload_id,omitempty"`
-	// TLSProtectCloudUploadPath is the endpoint path for the upload API.
-	TLSProtectCloudUploadPath string `yaml:"upload_path,omitempty"`
+	OutputPath  string             `yaml:"output-path"`
+	VenafiCloud *VenafiCloudConfig `yaml:"venafi-cloud,omitempty"`
 }
 
 type Endpoint struct {
@@ -49,6 +45,14 @@ type DataGatherer struct {
 	Name     string `yaml:"name"`
 	DataPath string `yaml:"data_path"`
 	Config   datagatherer.Config
+}
+
+type VenafiCloudConfig struct {
+	// UploadID is the upload ID that will be used when
+	// creating a cluster connection
+	UploadID string `yaml:"upload_id,omitempty"`
+	// UploadPath is the endpoint path for the upload API.
+	UploadPath string `yaml:"upload_path,omitempty"`
 }
 
 func reMarshal(rawConfig interface{}, config datagatherer.Config) error {
@@ -125,16 +129,16 @@ func (c *Config) Dump() (string, error) {
 func (c *Config) validate() error {
 	var result *multierror.Error
 
-	// configured for TLS Protect Cloud
-	if c.TLSProtectCloudkUploadID != "" || c.TLSProtectCloudUploadPath != "" {
-		if c.TLSProtectCloudkUploadID == "" {
-			result = multierror.Append(result, fmt.Errorf("upload_id is required in TLS Protect Cloud mode"))
+	// configured for Venafi Cloud
+	if c.VenafiCloud != nil {
+		if c.VenafiCloud.UploadID == "" {
+			result = multierror.Append(result, fmt.Errorf("upload_id is required in Venafi Cloud mode"))
 		}
-		if c.TLSProtectCloudUploadPath == "" {
-			result = multierror.Append(result, fmt.Errorf("upload_path is required in TLS Protect Cloud mode"))
+		if c.VenafiCloud.UploadPath == "" {
+			result = multierror.Append(result, fmt.Errorf("upload_path is required in Venafi Cloud mode"))
 		}
 
-		if _, err := url.Parse(c.TLSProtectCloudUploadPath); err != nil {
+		if _, err := url.Parse(c.VenafiCloud.UploadPath); err != nil {
 			result = multierror.Append(result, fmt.Errorf("upload_path is not a valid URL"))
 		}
 	} else {

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -178,7 +178,11 @@ func ParseConfig(data []byte) (Config, error) {
 	}
 
 	if config.Server == "" && config.Endpoint.Host == "" && config.Endpoint.Path == "" {
-		config.Server = "https://preflight.jetstack.io"
+		if config.VenafiCloud != nil {
+			config.Server = "https://api.venafi.cloud"
+		} else {
+			config.Server = "https://preflight.jetstack.io"
+		}
 	}
 
 	if config.Endpoint.Protocol == "" && config.Server == "" {

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -98,12 +98,10 @@ func TestValidConfigWithEndpointLoad(t *testing.T) {
 	}
 }
 
-func TestValidTLSProtectCloudConfigLoad(t *testing.T) {
+func TestValidVenafiCloudConfigLoad(t *testing.T) {
 	configFileContents := `
       server: "http://localhost:8080"
       period: 1h
-      upload_id: test-agent
-      upload_path: "/testing/path"
       data-gatherers:
       - name: d1
         kind: dummy
@@ -111,6 +109,9 @@ func TestValidTLSProtectCloudConfigLoad(t *testing.T) {
           always-fail: false
       input-path: "/home"
       output-path: "/nothome"
+      venafi-cloud: 
+        upload_id: test-agent
+        upload_path: "/testing/path"
 `
 
 	loadedConfig, err := ParseConfig([]byte(configFileContents))
@@ -132,10 +133,12 @@ func TestValidTLSProtectCloudConfigLoad(t *testing.T) {
 				},
 			},
 		},
-		InputPath:                 "/home",
-		OutputPath:                "/nothome",
-		TLSProtectCloudkUploadID:  "test-agent",
-		TLSProtectCloudUploadPath: "/testing/path",
+		InputPath:  "/home",
+		OutputPath: "/nothome",
+		VenafiCloud: &VenafiCloudConfig{
+			UploadID:   "test-agent",
+			UploadPath: "/testing/path",
+		},
 	}
 
 	if diff, equal := messagediff.PrettyDiff(expected, loadedConfig); !equal {

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -110,7 +110,7 @@ func TestValidVenafiCloudConfigLoad(t *testing.T) {
       input-path: "/home"
       output-path: "/nothome"
       venafi-cloud: 
-        upload_id: test-agent
+        uploader_id: test-agent
         upload_path: "/testing/path"
 `
 
@@ -136,7 +136,7 @@ func TestValidVenafiCloudConfigLoad(t *testing.T) {
 		InputPath:  "/home",
 		OutputPath: "/nothome",
 		VenafiCloud: &VenafiCloudConfig{
-			UploadID:   "test-agent",
+			UploaderID: "test-agent",
 			UploadPath: "/testing/path",
 		},
 	}

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -98,6 +98,51 @@ func TestValidConfigWithEndpointLoad(t *testing.T) {
 	}
 }
 
+func TestValidTLSProtectCloudConfigLoad(t *testing.T) {
+	configFileContents := `
+      server: "http://localhost:8080"
+      period: 1h
+      upload_id: test-agent
+      upload_path: "/testing/path"
+      data-gatherers:
+      - name: d1
+        kind: dummy
+        config:
+          always-fail: false
+      input-path: "/home"
+      output-path: "/nothome"
+`
+
+	loadedConfig, err := ParseConfig([]byte(configFileContents))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := Config{
+		Server:         "http://localhost:8080",
+		Period:         time.Hour,
+		OrganizationID: "",
+		ClusterID:      "",
+		DataGatherers: []DataGatherer{
+			{
+				Name: "d1",
+				Kind: "dummy",
+				Config: &dummyConfig{
+					AlwaysFail: false,
+				},
+			},
+		},
+		InputPath:                 "/home",
+		OutputPath:                "/nothome",
+		TLSProtectCloudkUploadID:  "test-agent",
+		TLSProtectCloudUploadPath: "/testing/path",
+	}
+
+	if diff, equal := messagediff.PrettyDiff(expected, loadedConfig); !equal {
+		t.Errorf("Diff %s", diff)
+	}
+}
+
 func TestInvalidConfigError(t *testing.T) {
 	configFileContents := `data-gatherers: "things"`
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -278,7 +278,7 @@ func createCredentialClient(credentials client.Credentials, config Config, agent
 		if config.VenafiCloud == nil {
 			log.Fatalf("Failed to find config for venafi-cloud: required for Venafi Cloud mode")
 		}
-		return client.NewVenafiCloudClient(agentMetadata, creds, baseURL, config.VenafiCloud.UploadID, config.VenafiCloud.UploadPath)
+		return client.NewVenafiCloudClient(agentMetadata, creds, baseURL, config.VenafiCloud.UploaderID, config.VenafiCloud.UploadPath)
 
 	case *client.OAuthCredentials:
 		log.Println("A credentials file was specified, using oauth authentication.")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -15,6 +15,11 @@ type (
 		PostDataReadings(orgID, clusterID string, readings []*api.DataReading) error
 		Post(path string, body io.Reader) (*http.Response, error)
 	}
+
+	Credentials interface {
+		IsClientSet() bool
+		Validate() error
+	}
 )
 
 func fullURL(baseURL, path string) string {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,7 @@ type (
 		Post(path string, body io.Reader) (*http.Response, error)
 	}
 
+	// The Credentials interface describes methods for credential types to implement for verification.
 	Credentials interface {
 		IsClientSet() bool
 		Validate() error

--- a/pkg/client/client_oauth.go
+++ b/pkg/client/client_oauth.go
@@ -215,7 +215,7 @@ func (c *OAuthClient) renewAccessToken() error {
 }
 
 // ParseOAuthCredentials reads credentials into an OAuthCredentials struct. Performs validations.
-func ParseOAuthCredentials(data []byte) (Credentials, error) {
+func ParseOAuthCredentials(data []byte) (*OAuthCredentials, error) {
 	var credentials OAuthCredentials
 
 	err := json.Unmarshal(data, &credentials)

--- a/pkg/client/client_oauth.go
+++ b/pkg/client/client_oauth.go
@@ -21,7 +21,7 @@ type (
 	// The OAuthClient type is a Client implementation used to upload data readings to the Jetstack Secure platform
 	// using OAuth as its authentication method.
 	OAuthClient struct {
-		credentials   *Credentials
+		credentials   *OAuthCredentials
 		accessToken   *accessToken
 		baseURL       string
 		agentMetadata *api.AgentMetadata
@@ -33,8 +33,8 @@ type (
 		expirationDate time.Time
 	}
 
-	// Credentials defines the format of the credentials.json file.
-	Credentials struct {
+	// OAuthCredentials defines the format of the credentials.json file.
+	OAuthCredentials struct {
 		// UserID is the ID or email for the user or service account.
 		UserID string `json:"user_id"`
 		// UserSecret is the secret for the user or service account.
@@ -68,8 +68,8 @@ func (t *accessToken) needsRenew() bool {
 
 // NewOAuthClient returns a new instance of the OAuthClient type that will perform HTTP requests using OAuth to provide
 // authentication tokens to the backend API.
-func NewOAuthClient(agentMetadata *api.AgentMetadata, credentials *Credentials, baseURL string) (*OAuthClient, error) {
-	if err := credentials.validate(); err != nil {
+func NewOAuthClient(agentMetadata *api.AgentMetadata, credentials *OAuthCredentials, baseURL string) (*OAuthClient, error) {
+	if err := credentials.Validate(); err != nil {
 		return nil, fmt.Errorf("cannot create OAuthClient: %v", err)
 	}
 	if baseURL == "" {
@@ -214,16 +214,16 @@ func (c *OAuthClient) renewAccessToken() error {
 	return nil
 }
 
-// ParseCredentials reads credentials into a struct used. Performs validations.
-func ParseCredentials(data []byte) (*Credentials, error) {
-	var credentials Credentials
+// ParseOAuthCredentials reads credentials into an OAuthCredentials struct. Performs validations.
+func ParseOAuthCredentials(data []byte) (Credentials, error) {
+	var credentials OAuthCredentials
 
 	err := json.Unmarshal(data, &credentials)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = credentials.validate(); err != nil {
+	if err = credentials.Validate(); err != nil {
 		return nil, err
 	}
 
@@ -231,11 +231,11 @@ func ParseCredentials(data []byte) (*Credentials, error) {
 }
 
 // IsClientSet returns whether the client credentials are set or not.
-func (c *Credentials) IsClientSet() bool {
+func (c *OAuthCredentials) IsClientSet() bool {
 	return c.ClientID != "" && c.ClientSecret != "" && c.AuthServerDomain != ""
 }
 
-func (c *Credentials) validate() error {
+func (c *OAuthCredentials) Validate() error {
 	var result *multierror.Error
 
 	if c == nil {

--- a/pkg/client/client_tls_protect_cloud.go
+++ b/pkg/client/client_tls_protect_cloud.go
@@ -1,0 +1,380 @@
+package client
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/jetstack/preflight/api"
+	"gopkg.in/yaml.v2"
+)
+
+type (
+	// The TLSProtectCloudClient type is a Client implementation used to upload data readings to the TLS Protect Cloud platform
+	// using service account authentication as its authentication method.
+	//
+	// This form of authentication follows the Private Key JWT standard found at https://oauth.net/private-key-jwt, 
+	// which is a combination of two RFCs:
+	// * RFC 7521 (Assertion Framework)
+	// * RFC 7523 (JWT Profile for Client Authentication)
+	TLSProtectCloudClient struct {
+		credentials   *TLSProtectCloudCredentials
+		accessToken   *tlsProtectCloudAccessToken
+		baseURL       string
+		agentMetadata *api.AgentMetadata
+		client        *http.Client
+
+		uploadID      string
+		uploadPath    string
+		privateKey    crypto.PrivateKey
+		jwtSigningAlg jwt.SigningMethod
+		lock          sync.RWMutex
+	}
+
+	TLSProtectCloudCredentials struct {
+		// ClientID is the service account client ID
+		ClientID string `yaml:"client_id,omitempty"`
+		// PrivateKeyFile is the path to the private key file paired to
+		// the public key in the service account
+		PrivateKeyFile string `yaml:"private_key_file,omitempty"`
+	}
+
+	tlsProtectCloudAccessToken struct {
+		accessToken    string
+		expirationTime time.Time
+	}
+
+	accessTokenInformation struct {
+		AccessToken string `json:"access_token"` //base 64 encoded token
+		Type        string `json:"token_type"`   // always be “bearer” for now
+		ExpiresIn   int64  `json:"expires_in"`   // number of seconds after which the access token will expire
+	}
+)
+
+const (
+	vaasProdURL         = "https://api.venafi.cloud"
+	accessTokenEndpoint = "/v1/oauth/token/serviceaccount"
+	requiredGrantType   = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+)
+
+// NewTLSProtectCloudClient returns a new instance of the TLSProtectCloudClient type that will perform HTTP requests using a bearer token
+// to authenticate to the backend API.
+func NewTLSProtectCloudClient(agentMetadata *api.AgentMetadata, credentials *TLSProtectCloudCredentials, baseURL string, uploadID string, uploadPath string) (*TLSProtectCloudClient, error) {
+	if err := credentials.validate(); err != nil {
+		return nil, fmt.Errorf("cannot create TLSProtectCloudClient: %v", err)
+	}
+	privateKey, jwtSigningAlg, err := parsePrivateKeyAndExtractSigningMethod(credentials.PrivateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing private key file %v", err)
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf("cannot create TLSProtectCloudClient: baseURL cannot be empty")
+	}
+
+	if !credentials.isClientSet() {
+		return nil, fmt.Errorf("cannot create TLSProtectCloudClient: invalid TLS Protect Cloud client configuration")
+	}
+
+	return &TLSProtectCloudClient{
+		agentMetadata: agentMetadata,
+		credentials:   credentials,
+		baseURL:       baseURL,
+		accessToken:   &tlsProtectCloudAccessToken{},
+		client:        &http.Client{Timeout: time.Minute},
+		uploadID:      uploadID,
+		uploadPath:    uploadPath,
+		privateKey:    privateKey,
+		jwtSigningAlg: jwtSigningAlg,
+	}, nil
+}
+
+// ParseTLSProtectCloudCredentials reads credentials into a struct used. Performs validations.
+func ParseTLSProtectCloudCredentials(data []byte) (*TLSProtectCloudCredentials, error) {
+	var credentials TLSProtectCloudCredentials
+
+	err := yaml.Unmarshal(data, &credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = credentials.validate(); err != nil {
+		return nil, err
+	}
+
+	return &credentials, nil
+}
+
+func (c *TLSProtectCloudCredentials) validate() error {
+	var result *multierror.Error
+
+	if c == nil {
+		return fmt.Errorf("credentials are nil")
+	}
+
+	if c.ClientID == "" {
+		result = multierror.Append(result, fmt.Errorf("client_id cannot be empty"))
+	}
+
+	if c.PrivateKeyFile == "" {
+		result = multierror.Append(result, fmt.Errorf("private_key_file cannot be empty"))
+	}
+
+	return result.ErrorOrNil()
+}
+
+// IsClientSet returns whether the client credentials are set or not.
+func (c *TLSProtectCloudCredentials) isClientSet() bool {
+	return c.ClientID != "" && c.PrivateKeyFile != ""
+}
+
+// PostDataReadings uploads the slice of api.DataReading to the TLS Protect Cloud backend to be processed for later
+// viewing in the user-interface.
+func (c *TLSProtectCloudClient) PostDataReadings(_ string, _ string, readings []*api.DataReading) error {
+	// orgID and clusterID are ignored due to no need for orgID and clusterID
+
+	payload := api.DataReadingsPost{
+		AgentMetadata:  c.agentMetadata,
+		DataGatherTime: time.Now().UTC(),
+		DataReadings:   readings,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(c.uploadPath, "/") {
+		c.uploadPath = fmt.Sprintf("%s/", c.uploadPath)
+	}
+	res, err := c.Post(filepath.Join(c.uploadPath, c.uploadID), bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if code := res.StatusCode; code < 200 || code >= 300 {
+		errorContent := ""
+		body, err := ioutil.ReadAll(res.Body)
+		if err == nil {
+			errorContent = string(body)
+		}
+		return fmt.Errorf("received response with status code %d. Body: %s", code, errorContent)
+	}
+
+	return nil
+}
+
+// Post performs an HTTP POST request.
+func (c *TLSProtectCloudClient) Post(path string, body io.Reader) (*http.Response, error) {
+	token, err := c.getValidAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fullURL(c.baseURL, path), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	if len(token.accessToken) > 0 {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.accessToken))
+	}
+
+	return c.client.Do(req)
+}
+
+// getValidAccessToken returns a valid access token. It will fetch a new access
+// token from the auth server in case the current access token does not exist
+// or it is expired.
+func (c *TLSProtectCloudClient) getValidAccessToken() (*tlsProtectCloudAccessToken, error) {
+	if c.accessToken == nil || time.Now().Add(time.Minute).After(c.accessToken.expirationTime) {
+		err := c.updateAccessToken()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return c.accessToken, nil
+}
+
+func (c *TLSProtectCloudClient) updateAccessToken() error {
+	jwtToken, err := c.generateAndSignJwtToken()
+	if err != nil {
+		return err
+	}
+
+	values := url.Values{}
+	values.Set("grant_type", requiredGrantType)
+	values.Set("assertion", jwtToken)
+
+	tokenURL := fullURL(c.baseURL, accessTokenEndpoint)
+	if err != nil {
+		return err
+	}
+
+	encoded := values.Encode()
+	request, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(encoded))
+	if err != nil {
+		return err
+	}
+
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Add("Content-Length", strconv.Itoa(len(encoded)))
+
+	now := time.Now()
+	accessToken := accessTokenInformation{}
+	err = c.sendHTTPRequest(request, &accessToken)
+	if err != nil {
+		return err
+	}
+
+	c.lock.Lock()
+	c.accessToken = &tlsProtectCloudAccessToken{
+		accessToken:    accessToken.AccessToken,
+		expirationTime: now.Add(time.Duration(accessToken.ExpiresIn) * time.Second),
+	}
+	c.lock.Unlock()
+	return nil
+}
+
+func (c *TLSProtectCloudClient) sendHTTPRequest(request *http.Request, responseObject interface{}) error {
+	response, err := c.client.Do(request)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err = response.Body.Close(); err != nil {
+		}
+	}()
+
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("failed to execute http request to VaaS. Request %s, status code: %d, body: %s", request.URL, response.StatusCode, body)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(body, responseObject); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *TLSProtectCloudClient) generateAndSignJwtToken() (string, error) {
+	prodURL, err := url.Parse(vaasProdURL)
+	if err != nil {
+		return "", err
+	}
+
+	claims := make(jwt.MapClaims)
+	claims["sub"] = c.credentials.ClientID
+	claims["iss"] = c.credentials.ClientID
+	claims["iat"] = time.Now().Unix()
+	claims["exp"] = time.Now().Add(time.Minute).Unix()
+	claims["aud"] = path.Join(prodURL.Host, accessTokenEndpoint)
+	claims["jti"] = uuid.New().String()
+
+	token, err := jwt.NewWithClaims(c.jwtSigningAlg, claims).SignedString(c.privateKey)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+func parsePrivateKeyFromPemFile(privateKeyFilePath string) (crypto.PrivateKey, error) {
+	pkBytes, err := os.ReadFile(privateKeyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch TLS Protect Cloud authentication private key %q: %s",
+			privateKeyFilePath, err)
+	}
+
+	der, _ := pem.Decode(pkBytes)
+	if der == nil {
+		return nil, fmt.Errorf("error decoding private key from pem file %q", privateKeyFilePath)
+	}
+
+	if key, err := x509.ParsePKCS1PrivateKey(der.Bytes); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(der.Bytes); err == nil {
+		switch key := key.(type) {
+		case *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey:
+			return key, nil
+		default:
+			return nil, fmt.Errorf("found unknown private key type in PKCS#8 wrapping")
+		}
+	}
+	if key, err := x509.ParseECPrivateKey(der.Bytes); err == nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("failed to parse private key")
+}
+
+func parsePrivateKeyAndExtractSigningMethod(privateKeyFile string) (crypto.PrivateKey, jwt.SigningMethod, error) {
+
+	privateKey, err := parsePrivateKeyFromPemFile(privateKeyFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var signingMethod jwt.SigningMethod
+	switch key := privateKey.(type) {
+	case *rsa.PrivateKey:
+		bitLen := key.N.BitLen()
+		switch bitLen {
+		case 2048:
+			signingMethod = jwt.SigningMethodRS256
+		case 3072:
+			signingMethod = jwt.SigningMethodRS384
+		case 4096:
+			signingMethod = jwt.SigningMethodRS512
+		default:
+			signingMethod = jwt.SigningMethodRS256
+		}
+	case *ecdsa.PrivateKey:
+		bitLen := key.Curve.Params().BitSize
+		switch bitLen {
+		case 256:
+			signingMethod = jwt.SigningMethodES256
+		case 384:
+			signingMethod = jwt.SigningMethodES384
+		case 521:
+			signingMethod = jwt.SigningMethodES512
+		default:
+			signingMethod = jwt.SigningMethodES256
+		}
+	case ed25519.PrivateKey:
+		signingMethod = jwt.SigningMethodEdDSA
+	default:
+		err = fmt.Errorf("unsupported private key type")
+	}
+	return privateKey, signingMethod, err
+}

--- a/pkg/client/client_venafi_cloud.go
+++ b/pkg/client/client_venafi_cloud.go
@@ -11,7 +11,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -26,7 +25,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jetstack/preflight/api"
-	"gopkg.in/yaml.v2"
 )
 
 type (
@@ -53,10 +51,10 @@ type (
 
 	VenafiSvcAccountCredentials struct {
 		// ClientID is the service account client ID
-		ClientID string `yaml:"client_id,omitempty"`
+		ClientID string `json:"client_id,omitempty"`
 		// PrivateKeyFile is the path to the private key file paired to
 		// the public key in the service account
-		PrivateKeyFile string `yaml:"private_key_file,omitempty"`
+		PrivateKeyFile string `json:"private_key_file,omitempty"`
 	}
 
 	venafiCloudAccessToken struct {
@@ -109,10 +107,10 @@ func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiS
 }
 
 // ParseVenafiCredentials reads credentials into a VenafiSvcAccountCredentials struct. Performs validations.
-func ParseVenafiCredentials(data []byte) (Credentials, error) {
+func ParseVenafiCredentials(data []byte) (*VenafiSvcAccountCredentials, error) {
 	var credentials VenafiSvcAccountCredentials
 
-	err := yaml.Unmarshal(data, &credentials)
+	err := json.Unmarshal(data, &credentials)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +171,7 @@ func (c *VenafiCloudClient) PostDataReadings(_ string, _ string, readings []*api
 
 	if code := res.StatusCode; code < 200 || code >= 300 {
 		errorContent := ""
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err == nil {
 			errorContent = string(body)
 		}

--- a/pkg/client/client_venafi_cloud.go
+++ b/pkg/client/client_venafi_cloud.go
@@ -42,7 +42,7 @@ type (
 		agentMetadata *api.AgentMetadata
 		client        *http.Client
 
-		uploadID      string
+		uploaderID    string
 		uploadPath    string
 		privateKey    crypto.PrivateKey
 		jwtSigningAlg jwt.SigningMethod
@@ -77,7 +77,7 @@ const (
 
 // NewVenafiCloudClient returns a new instance of the VenafiCloudClient type that will perform HTTP requests using a bearer token
 // to authenticate to the backend API.
-func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiSvcAccountCredentials, baseURL string, uploadID string, uploadPath string) (*VenafiCloudClient, error) {
+func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiSvcAccountCredentials, baseURL string, uploaderID string, uploadPath string) (*VenafiCloudClient, error) {
 	if err := credentials.Validate(); err != nil {
 		return nil, fmt.Errorf("cannot create VenafiCloudClient: %v", err)
 	}
@@ -99,7 +99,7 @@ func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiS
 		baseURL:       baseURL,
 		accessToken:   &venafiCloudAccessToken{},
 		client:        &http.Client{Timeout: time.Minute},
-		uploadID:      uploadID,
+		uploaderID:    uploaderID,
 		uploadPath:    uploadPath,
 		privateKey:    privateKey,
 		jwtSigningAlg: jwtSigningAlg,
@@ -163,7 +163,7 @@ func (c *VenafiCloudClient) PostDataReadings(_ string, _ string, readings []*api
 	if !strings.HasSuffix(c.uploadPath, "/") {
 		c.uploadPath = fmt.Sprintf("%s/", c.uploadPath)
 	}
-	res, err := c.Post(filepath.Join(c.uploadPath, c.uploadID), bytes.NewBuffer(data))
+	res, err := c.Post(filepath.Join(c.uploadPath, c.uploaderID), bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds the ability to add authentication for TLS Protect Cloud to the agent for uploading cluster information. A new flag is introduced to pass a new type of credentials file.