### PR TITLE
Add missing required fields to cert-manager example

### DIFF
--- a/examples/cert-manager-agent.yaml
+++ b/examples/cert-manager-agent.yaml
@@ -1,3 +1,5 @@
+organization_id: "my-organization"
+cluster_id: "my_cluster"
 schedule: "* * * *"
 token: xxxx
 endpoint:


### PR DESCRIPTION
Without these fields I get the following error when trying to use the example:

```console
$ go run ./ agent --one-shot --output-path ./output  --agent-config-file examples/cert-manager-agent.yaml
2023/06/09 13:12:23 Preflight agent version: development ()
2023/06/09 13:12:23 Failed to parse config file: 2 errors occurred:
        * organization_id is required
        * cluster_id is required

exit status 1
```

After adding these fields, the one-shot discovery works:

```console
$ go run ./ agent --one-shot --output-path ./output  --agent-config-file examples/cert-manager-agent.yaml
2023/06/09 13:12:33 Preflight agent version: development ()
2023/06/09 13:12:33 Using deprecated Endpoint configuration. User Server instead.
2023/06/09 13:12:33 Loaded config:
schedule: '* * * *'
period: 0s
endpoint:
  protocol: https
  host: preflight.jetstack.io
  path: /api/v1/datareadings
server: ""
organization_id: my-organization
cluster_id: my_cluster
data-gatherers:
- kind: k8s-dynamic
  name: k8s/secrets.v1
  data_path: ""
  config:
    kubeconfig: ""
    groupversionresource:
      group: ""
      version: v1
      resource: secrets
    exclude-namespaces: []
    include-namespaces: []
- kind: k8s-dynamic
  name: k8s/certificates.v1alpha2.cert-manager.io
  data_path: ""
  config:
    kubeconfig: ""
    groupversionresource:
      group: cert-manager.io
      version: v1alpha2
      resource: certificates
    exclude-namespaces: []
    include-namespaces: []
- kind: k8s-dynamic
  name: k8s/ingresses.v1beta1.networking.k8s.io
  data_path: ""
  config:
    kubeconfig: ""
    groupversionresource:
      group: networking.k8s.io
      version: v1beta1
      resource: ingresses
    exclude-namespaces: []
    include-namespaces: []
- kind: k8s-dynamic
  name: k8s/certificaterequests.v1alpha2.cert-manager.io
  data_path: ""
  config:
    kubeconfig: ""
    groupversionresource:
      group: cert-manager.io
      version: v1alpha2
      resource: certificaterequests
    exclude-namespaces: []
    include-namespaces: []
input-path: ""
output-path: ""
2023/06/09 13:12:33 No credentials were specified, using with no authentication.
2023/06/09 13:12:33 starting "k8s/certificates.v1alpha2.cert-manager.io" datagatherer
2023/06/09 13:12:33 starting "k8s/ingresses.v1beta1.networking.k8s.io" datagatherer
2023/06/09 13:12:33 starting "k8s/certificaterequests.v1alpha2.cert-manager.io" datagatherer
2023/06/09 13:12:33 waiting for datagatherers to complete inital syncs
2023/06/09 13:12:33 starting "k8s/certificaterequests.v1alpha2.cert-manager.io" datagatherer
W0609 13:12:33.210086   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:33 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificaterequests"
W0609 13:12:33.210224   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:33 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificates"
W0609 13:12:33.210494   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:33 server missing resource for datagatherer of "networking.k8s.io/v1beta1, Resource=ingresses"
W0609 13:12:34.497801   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:34 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificaterequests"
W0609 13:12:34.547904   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:34 server missing resource for datagatherer of "networking.k8s.io/v1beta1, Resource=ingresses"
W0609 13:12:34.769930   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:34 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificates"
W0609 13:12:36.481111   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:36 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificates"
W0609 13:12:36.785583   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:36 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificaterequests"
W0609 13:12:37.251903   45268 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.3/tools/cache/reflector.go:169: failed to list *unstructured.Unstructured: the server could not find the requested resource
2023/06/09 13:12:37 server missing resource for datagatherer of "networking.k8s.io/v1beta1, Resource=ingresses"
2023/06/09 13:12:38 failed to complete initial sync of "k8s-dynamic" data gatherer "k8s/certificaterequests.v1alpha2.cert-manager.io": timed out waiting for caches to sync, using parent stop channel
2023/06/09 13:12:38 failed to complete initial sync of "k8s-dynamic" data gatherer "k8s/certificaterequests.v1alpha2.cert-manager.io": timed out waiting for caches to sync, using parent stop channel
2023/06/09 13:12:38 failed to complete initial sync of "k8s-dynamic" data gatherer "k8s/certificaterequests.v1alpha2.cert-manager.io": timed out waiting for caches to sync, using parent stop channel
2023/06/09 13:12:38 datagatherers inital sync completed
2023/06/09 13:12:38 successfully gathered data from "k8s/certificaterequests.v1alpha2.cert-manager.io" datagatherer
2023/06/09 13:12:38 successfully gathered data from "k8s/secrets.v1" datagatherer
2023/06/09 13:12:38 successfully gathered data from "k8s/certificates.v1alpha2.cert-manager.io" datagatherer
2023/06/09 13:12:38 successfully gathered data from "k8s/ingresses.v1beta1.networking.k8s.io" datagatherer
2023/06/09 13:12:38 Data saved to local file: ./output
```