### PR TITLE
Refactor the venafi-cloud configuration

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -41,7 +41,7 @@ var agentRBACCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Failed to read config file: %s", err)
 		}
-		config, err := agent.ParseConfig(b)
+		config, err := agent.ParseConfig(b, false)
 		if err != nil {
 			log.Fatalf("Failed to parse config file: %s", err)
 		}

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -127,7 +127,7 @@ func (c *Config) Dump() (string, error) {
 	return string(d), nil
 }
 
-func (c *Config) validate(isVenafi bool) error {
+func (c *Config) validate(isVenafiCloudMode bool) error {
 	var result *multierror.Error
 
 	// configured for Venafi Cloud
@@ -139,7 +139,7 @@ func (c *Config) validate(isVenafi bool) error {
 		if _, err := url.Parse(c.VenafiCloud.UploadPath); err != nil {
 			result = multierror.Append(result, fmt.Errorf("upload_path is not a valid URL"))
 		}
-	} else if !isVenafi {
+	} else if !isVenafiCloudMode {
 		if c.OrganizationID == "" {
 			result = multierror.Append(result, fmt.Errorf("organization_id is required"))
 		}
@@ -167,7 +167,7 @@ func (c *Config) validate(isVenafi bool) error {
 }
 
 // ParseConfig reads config into a struct used to configure running agents
-func ParseConfig(data []byte, isVenafi bool) (Config, error) {
+func ParseConfig(data []byte, isVenafiCloudMode bool) (Config, error) {
 	var config Config
 
 	err := yaml.Unmarshal(data, &config)
@@ -186,7 +186,7 @@ func ParseConfig(data []byte, isVenafi bool) (Config, error) {
 		config.Endpoint.Protocol = "http"
 	}
 
-	err = config.validate(isVenafi)
+	err = config.validate(isVenafiCloudMode)
 	if err != nil {
 		return config, err
 	}

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/jetstack/preflight/pkg/client"
 	"github.com/jetstack/preflight/pkg/datagatherer"
 	"github.com/jetstack/preflight/pkg/datagatherer/k8s"
 	"github.com/jetstack/preflight/pkg/datagatherer/local"
@@ -131,9 +132,6 @@ func (c *Config) validate() error {
 
 	// configured for Venafi Cloud
 	if c.VenafiCloud != nil {
-		if c.VenafiCloud.UploaderID == "" {
-			result = multierror.Append(result, fmt.Errorf("upload_id is required in Venafi Cloud mode"))
-		}
 		if c.VenafiCloud.UploadPath == "" {
 			result = multierror.Append(result, fmt.Errorf("upload_path is required in Venafi Cloud mode"))
 		}
@@ -178,10 +176,9 @@ func ParseConfig(data []byte) (Config, error) {
 	}
 
 	if config.Server == "" && config.Endpoint.Host == "" && config.Endpoint.Path == "" {
+		config.Server = "https://preflight.jetstack.io"
 		if config.VenafiCloud != nil {
-			config.Server = "https://api.venafi.cloud"
-		} else {
-			config.Server = "https://preflight.jetstack.io"
+			config.Server = client.VenafiCloudProdURL
 		}
 	}
 

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -127,7 +127,7 @@ func (c *Config) Dump() (string, error) {
 	return string(d), nil
 }
 
-func (c *Config) validate() error {
+func (c *Config) validate(isVenafi bool) error {
 	var result *multierror.Error
 
 	// configured for Venafi Cloud
@@ -139,7 +139,7 @@ func (c *Config) validate() error {
 		if _, err := url.Parse(c.VenafiCloud.UploadPath); err != nil {
 			result = multierror.Append(result, fmt.Errorf("upload_path is not a valid URL"))
 		}
-	} else {
+	} else if !isVenafi {
 		if c.OrganizationID == "" {
 			result = multierror.Append(result, fmt.Errorf("organization_id is required"))
 		}
@@ -167,7 +167,7 @@ func (c *Config) validate() error {
 }
 
 // ParseConfig reads config into a struct used to configure running agents
-func ParseConfig(data []byte) (Config, error) {
+func ParseConfig(data []byte, isVenafi bool) (Config, error) {
 	var config Config
 
 	err := yaml.Unmarshal(data, &config)
@@ -186,7 +186,8 @@ func ParseConfig(data []byte) (Config, error) {
 		config.Endpoint.Protocol = "http"
 	}
 
-	if err = config.validate(); err != nil {
+	err = config.validate(isVenafi)
+	if err != nil {
 		return config, err
 	}
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -198,11 +198,8 @@ func getConfiguration() (Config, client.Client) {
 		log.Fatalf("Failed to read config file: %s", err)
 	}
 
-	config, err := ParseConfig(b)
-	switch {
-	case err != nil && VenafiCloudMode && (config.OrganizationID == "" || config.ClusterID == ""):
-	// venafi-cloud does not require the OrganizationID or ClusterID, do not error in case they are missing
-	case err != nil:
+	config, err := ParseConfig(b, VenafiCloudMode)
+	if err != nil {
 		log.Fatalf("Failed to parse config file: %s", err)
 	}
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -199,8 +199,16 @@ func getConfiguration() (Config, client.Client) {
 	}
 
 	config, err := ParseConfig(b)
-	if err != nil {
+	switch {
+	case err != nil && VenafiCloudMode && (config.OrganizationID == "" || config.ClusterID == ""):
+	// venafi-cloud does not require the OrganizationID or ClusterID, do not error in case they are missing
+	case err != nil:
 		log.Fatalf("Failed to parse config file: %s", err)
+	}
+
+	if VenafiCloudMode {
+		// if the venafi-cloud mode is enabled override config.Server
+		config.Server = client.VenafiCloudProdURL
 	}
 
 	baseURL := config.Server
@@ -274,11 +282,15 @@ func createCredentialClient(credentials client.Credentials, config Config, agent
 	switch creds := credentials.(type) {
 	case *client.VenafiSvcAccountCredentials:
 		log.Println("Venafi Cloud mode was specified, using Venafi Service Account authentication.")
-		// check if config has Venafi Cloud data
-		if config.VenafiCloud == nil {
-			log.Fatalf("Failed to find config for venafi-cloud: required for Venafi Cloud mode")
+		// check if config has Venafi Cloud data, use config data if it's present
+		uploaderID := creds.ClientID
+		uploadPath := ""
+		if config.VenafiCloud != nil {
+			log.Println("Loading uploader_id and upload_path from \"venafi-cloud\" configuration.")
+			uploaderID = config.VenafiCloud.UploaderID
+			uploadPath = config.VenafiCloud.UploadPath
 		}
-		return client.NewVenafiCloudClient(agentMetadata, creds, baseURL, config.VenafiCloud.UploaderID, config.VenafiCloud.UploadPath)
+		return client.NewVenafiCloudClient(agentMetadata, creds, baseURL, uploaderID, uploadPath)
 
 	case *client.OAuthCredentials:
 		log.Println("A credentials file was specified, using oauth authentication.")

--- a/pkg/client/client_venafi_cloud.go
+++ b/pkg/client/client_venafi_cloud.go
@@ -70,9 +70,11 @@ type (
 )
 
 const (
-	vaasProdURL         = "https://api.venafi.cloud"
-	accessTokenEndpoint = "/v1/oauth/token/serviceaccount"
-	requiredGrantType   = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	// URL for the venafi-cloud backend services
+	VenafiCloudProdURL               = "https://api.venafi.cloud"
+	defaultVenafiCloudUploadEndpoint = "v1/tlspk/uploads"
+	accessTokenEndpoint              = "/v1/oauth/token/serviceaccount"
+	requiredGrantType                = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 )
 
 // NewVenafiCloudClient returns a new instance of the VenafiCloudClient type that will perform HTTP requests using a bearer token
@@ -91,6 +93,11 @@ func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiS
 
 	if !credentials.IsClientSet() {
 		return nil, fmt.Errorf("cannot create VenafiCloudClient: invalid Venafi Cloud client configuration")
+	}
+
+	if uploadPath == "" {
+		// if the uploadPath is not given, use default upload path
+		uploadPath = defaultVenafiCloudUploadEndpoint
 	}
 
 	return &VenafiCloudClient{
@@ -283,7 +290,7 @@ func (c *VenafiCloudClient) sendHTTPRequest(request *http.Request, responseObjec
 }
 
 func (c *VenafiCloudClient) generateAndSignJwtToken() (string, error) {
-	prodURL, err := url.Parse(vaasProdURL)
+	prodURL, err := url.Parse(VenafiCloudProdURL)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
These changes solidify the way users configure the agent to communicate to venafi-cloud. It allows the agent to set the `--venafi-cloud` without having to define 

```yaml
venafi-cloud:
  uploader_id: ""
  upload_path: ""
```
 in the `config.yaml`.
 
 The yaml configuration can still be used for a non default agent setup. It will override the default `uploader_id` and `upload_path`.