### PR TITLE
Allow server to be configured with `--venafi-cloud`

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -177,7 +177,7 @@ func ParseConfig(data []byte, isVenafiCloudMode bool) (Config, error) {
 
 	if config.Server == "" && config.Endpoint.Host == "" && config.Endpoint.Path == "" {
 		config.Server = "https://preflight.jetstack.io"
-		if config.VenafiCloud != nil {
+		if config.VenafiCloud != nil || isVenafiCloudMode {
 			config.Server = client.VenafiCloudProdURL
 		}
 	}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -203,11 +203,6 @@ func getConfiguration() (Config, client.Client) {
 		log.Fatalf("Failed to parse config file: %s", err)
 	}
 
-	if VenafiCloudMode {
-		// if the venafi-cloud mode is enabled override config.Server
-		config.Server = client.VenafiCloudProdURL
-	}
-
 	baseURL := config.Server
 	if baseURL == "" {
 		log.Printf("Using deprecated Endpoint configuration. User Server instead.")


### PR DESCRIPTION
This allows the server URL to be specified in the agent.yaml even when `--venafi-cloud` flag is present.