### PR TITLE
Allow to use ClientID and PrivateKeyPath as flags instead of credentials.json file

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -88,7 +88,7 @@ func init() {
 		"client-id",
 		"",
 		"",
-		"Venafi Cloud Service Account client ID. If you use this flag you don't need to use --venafi-cloud as it will assume you are authentiating against Venafi Cloud. Using this removed the need to use a credentials file with Venafi Cloud mode.",
+		"Venafi Cloud Service Account client ID. If you use this flag you don't need to use --venafi-cloud as it will assume you are authenticating against Venafi Cloud. Using this removes the need to use a credentials file with Venafi Cloud mode.",
 	)
 	agentCmd.PersistentFlags().StringVarP(
 		&agent.PrivateKeyPath,

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -81,7 +81,21 @@ func init() {
 		"venafi-cloud",
 		"",
 		false,
-		"Runs agent with parsing config and credentials file in Venafi Cloud format if true.",
+		"Runs agent with parsing config (and credentials file if provided) in Venafi Cloud format if true.",
+	)
+	agentCmd.PersistentFlags().StringVarP(
+		&agent.ClientID,
+		"client-id",
+		"",
+		"",
+		"Venafi Cloud Service Account client ID. If you use this flag you don't need to use --venafi-cloud as it will assume you are authentiating against Venafi Cloud. Using this removed the need to use a credentials file with Venafi Cloud mode.",
+	)
+	agentCmd.PersistentFlags().StringVarP(
+		&agent.PrivateKeyPath,
+		"private-key-path",
+		"",
+		"/etc/venafi/agent/key/privatekey.pem",
+		"Venafi Cloud Service Account private key path.",
 	)
 	agentCmd.PersistentFlags().BoolVarP(
 		&agent.OneShot,


### PR DESCRIPTION
This will help simplify #466.

This changes make it possible to use `--client-id` to specify the client ID (and optionally `--private-key-path`) when using the Venafi Cloud authentication, allowing the user to not need to provide a `credentials.json` file.

This change should be backwards compatible.