### PR TITLE
chore: Update agent version to latest

### DIFF
--- a/deploy/charts/jetstack-agent/Chart.yaml
+++ b/deploy/charts/jetstack-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: jetstack-agent
 description: TLS Protect for Kubernetes Agent
 type: application
-version: 0.3.0
-appVersion: "v0.1.40"
+version: 0.3.1
+appVersion: "v0.1.43"
 home: https://github.com/jetstack/jetstack-secure
 maintainers:
 - name: JSCP and CRE Team

--- a/deploy/charts/jetstack-agent/README.md
+++ b/deploy/charts/jetstack-agent/README.md
@@ -155,7 +155,7 @@ kubectl logs -n jetstack-secure $(kubectl get pod -n jetstack-secure -l app.kube
 | fullnameOverride | string | `""` | Helm default setting, use this to shorten install name |
 | image.pullPolicy | string | `"IfNotPresent"` | Defaults to only pull if not already present |
 | image.repository | string | `"quay.io/jetstack/preflight"` | Default to Open Source image repository |
-| image.tag | string | `"v0.1.40"` | Overrides the image tag whose default is the chart appVersion |
+| image.tag | string | `"v0.1.43"` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` | Specify image pull credentials if using a prviate registry |
 | nameOverride | string | `""` | Helm default setting to override release name, leave blank |
 | nodeSelector | object | `{}` |  |

--- a/deploy/charts/jetstack-agent/tests/__snapshot__/configuration_test.yaml.snap
+++ b/deploy/charts/jetstack-agent/tests/__snapshot__/configuration_test.yaml.snap
@@ -191,6 +191,6 @@ render correctly when only required config is given:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: jetstack-agent
-        app.kubernetes.io/version: v0.1.40
-        helm.sh/chart: jetstack-agent-0.3.0
+        app.kubernetes.io/version: v0.1.43
+        helm.sh/chart: jetstack-agent-0.3.1
       name: agent-config

--- a/deploy/charts/jetstack-agent/values.yaml
+++ b/deploy/charts/jetstack-agent/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Defaults to only pull if not already present
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion
-  tag: "v0.1.40"
+  tag: "v0.1.43"
 
 # -- Specify image pull credentials if using a prviate registry
 imagePullSecrets: []


### PR DESCRIPTION
Using the latest `jetstack-agent` chart it showed as out of date by the platform.
![image](https://github.com/jetstack/jetstack-secure/assets/11051419/6fd621fb-8c32-4445-9bda-b3765cac8eb1)

This fixes that.
