### PR TITLE
update agent config to upload firefly

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -198,6 +198,6 @@ data:
           group: firefly.venafi.com
           version: v1
           resource: issuers
-{{- ed }}
+{{- end }}
 
 

--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -197,5 +197,7 @@ data:
         resource-type:
           group: firefly.venafi.com
           version: v1
-          resource: fireflyissuers
+          resource: issuers
 {{- ed }}
+
+

--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -191,4 +191,11 @@ data:
           group: jetstack.io
           version: v1alpha1
           resource: venafiissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/fireflyissuers"
+      config:
+        resource-type:
+          group: firefly.venafi.com
+          version: v1
+          resource: firefly
 {{- end }}

--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -197,5 +197,5 @@ data:
         resource-type:
           group: firefly.venafi.com
           version: v1
-          resource: firefly
-{{- end }}
+          resource: fireflyissuers
+{{- ed }}


### PR DESCRIPTION
This PR implements [VC-30108](https://venafi.atlassian.net/browse/VC-30108) by updating the tlspk agent configuration to gather and update firefly.

Related to MR [#168](https://gitlab.com/venafi/vaas/applications/tls-protect-for-k8s/venctl/-/merge_requests/168/edit)

[VC-30108]: https://venafi.atlassian.net/browse/VC-30108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ