### PR TITLE
feat(helm): Add PodDisruptionBudget option to helm chart

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -2,7 +2,7 @@
 
 The Venafi Kubernetes Agent connects your Kubernetes or Openshift cluster to the Venafi Control Plane.
 
-![Version: 0.1.44](https://img.shields.io/badge/Version-0.1.44-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.44](https://img.shields.io/badge/AppVersion-v0.1.44-informational?style=flat-square)
+![Version: 0.1.45](https://img.shields.io/badge/Version-0.1.45-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.45](https://img.shields.io/badge/AppVersion-v0.1.45-informational?style=flat-square)
 
 ## Additional Information
 
@@ -157,11 +157,13 @@ You should see the following events for your service account:
 | fullnameOverride | string | `""` | Helm default setting, use this to shorten the full install name. |
 | image.pullPolicy | string | `"IfNotPresent"` | Defaults to only pull if not already present |
 | image.repository | string | `"quay.io/jetstack/venafi-agent"` | Default to Open Source image repository |
-| image.tag | string | `"v0.1.43"` | Overrides the image tag whose default is the chart appVersion |
+| image.tag | string | `"v0.1.45"` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` | Specify image pull credentials if using a private registry example: - name: my-pull-secret |
 | nameOverride | string | `""` | Helm default setting to override release name, usually leave blank. |
 | nodeSelector | object | `{}` | Embed YAML for nodeSelector settings, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/ |
 | podAnnotations | object | `{}` | Additional YAML annotations to add the the pod. |
+| podDisruptionBudget | object | `{"enabled":false}` | Configure a PodDisruptionBudget for the agent's Deployment. If running with multiple replicas, consider setting podDisruptionBudget.enabled to true. |
+| podDisruptionBudget.enabled | bool | `false` | Enable or disable the PodDisruptionBudget resource, which helps prevent downtime during voluntary disruptions such as during a Node upgrade. |
 | podSecurityContext | object | `{}` | Optional Pod (all containers) `SecurityContext` options, see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod. |
 | replicaCount | int | `1` | default replicas, do not scale up |
 | resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"200m","memory":"200Mi"}}` | Set custom resourcing settings for the pod. You may not want this if you intend to use a Vertical Pod Autoscaler. |

--- a/deploy/charts/venafi-kubernetes-agent/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "venafi-kubernetes-agent.selectorLabels" . | nindent 6 }}
+
+  {{- if not (or (hasKey .Values.podDisruptionBudget "minAvailable") (hasKey .Values.podDisruptionBudget "maxUnavailable")) }}
+  minAvailable: 1 # Default value because minAvailable and maxUnavailable are not set
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -101,3 +101,20 @@ config:
   configmap:
     name:
     key:
+
+# -- Configure a PodDisruptionBudget for the agent's Deployment. If running with multiple
+# replicas, consider setting podDisruptionBudget.enabled to true.
+podDisruptionBudget:
+  # -- Enable or disable the PodDisruptionBudget resource, which helps prevent downtime
+  # during voluntary disruptions such as during a Node upgrade.
+  enabled: false
+
+  # -- Configure the minimum available pods for disruptions. Can either be set to
+  # an integer (e.g. 1) or a percentage value (e.g. 25%).
+  # Cannot be used if `maxUnavailable` is set.
+  # minAvailable: 1
+
+  # -- Configure the maximum unavailable pods for disruptions. Can either be set to
+  # an integer (e.g. 1) or a percentage value (e.g. 25%).
+  # Cannot be used if `minAvailable` is set.
+  # maxUnavailable: 1


### PR DESCRIPTION
This brings the agent into line with many other open source charts (see e.g. cert-manager).

We document this as a best practice here:
https://docs.venafi.cloud/vaas/k8s-components/c-k8s-components-best-practice/#poddisruptionbudget

This is largely adapted from https://github.com/cert-manager/trust-manager/tree/main/deploy/charts/trust-manager !