### PR TITLE
Use agent image in the venafi repository

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/tests/deployment_test.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/tests/deployment_test.yaml
@@ -19,7 +19,7 @@ tests:
       # Check is latest is set as tag that it uses that tag
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/jetstack/venafi-agent:latest
+          value: registry.venafi.cloud/venafi-agent/venafi-agent:latest
 
   # Check naming works with nameOverride
   - it: Deployment name is set when nameOverride is used

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   # -- Default to Open Source image repository
-  repository: quay.io/jetstack/venafi-agent
+  repository: registry.venafi.cloud/venafi-agent/venafi-agent
   # -- Defaults to only pull if not already present
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion


### PR DESCRIPTION
Update the venafi-agent chart to use the image in the venafi public repository