### PR TITLE
Helm: the namespace was missing in the configmap, deployment, and serviceaccount templates

### DIFF
--- a/deploy/charts/jetstack-agent/templates/configmap.yaml
+++ b/deploy/charts/jetstack-agent/templates/configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: agent-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jetstack-agent.labels" . | nindent 4 }}
 data:

--- a/deploy/charts/jetstack-agent/templates/deployment.yaml
+++ b/deploy/charts/jetstack-agent/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "jetstack-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jetstack-agent.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/jetstack-agent/templates/secret.yaml
+++ b/deploy/charts/jetstack-agent/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.authentication.secretName}}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jetstack-agent.labels" . | nindent 4 }}
 type: Opaque

--- a/deploy/charts/jetstack-agent/templates/serviceaccount.yaml
+++ b/deploy/charts/jetstack-agent/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "jetstack-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jetstack-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/deploy/charts/jetstack-agent/tests/__snapshot__/configuration_test.yaml.snap
+++ b/deploy/charts/jetstack-agent/tests/__snapshot__/configuration_test.yaml.snap
@@ -194,3 +194,4 @@ render correctly when only required config is given:
         app.kubernetes.io/version: v0.1.43
         helm.sh/chart: jetstack-agent-0.3.1
       name: agent-config
+      namespace: NAMESPACE

--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: agent-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
 data:

--- a/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "venafi-kubernetes-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/venafi-kubernetes-agent/templates/serviceaccount.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Source: https://venafi.atlassian.net/browse/VC-32006

When installing with `helm install`, the namespace doesn't need to be present on the templates. Helm automatically installs the resources that don't have a specific namespace to the namespace specified in `--namespace`.

But when using `helm template`, the resulting templated manifests don't contain a namespace, even though `--namespace` was used. This is an old issue of Helm (https://github.com/helm/helm/issues/3553). And since a lot of people rely on `helm template` and then feed that into ArgoCD, it makes to add the `namespace` field to all namespaced resources.

Thus, this PR adds the `namespace` in the configmap, deployment, and serviceaccount templates.

Manual test **for the chart `venafi-kubernetes-agent`**:

```bash
# First, on master:
git checkout master
helm package ./deploy/charts/venafi-kubernetes-agent --version 0.0.0-master
# Second, on the PR:
gh pr checkout 526
helm package ./deploy/charts/venafi-kubernetes-agent --version 0.0.0-pr
diff -u \
  <(helm template venafi-kubernetes-agent-0.0.0-master.tgz -n venafi | grep -v "helm.sh/chart" | yq .kind,.metadata) \
  <(helm template venafi-kubernetes-agent-0.0.0-pr.tgz -n venafi | grep -v "helm.sh/chart" | yq .kind,.metadata)
```

Result:

```diff
--- /dev/fd/13	2024-03-26 15:32:10
+++ /dev/fd/15	2024-03-26 15:32:10
@@ -1,5 +1,6 @@
 ServiceAccount
 name: venafi-kubernetes-agent-release-name
+namespace: venafi
 labels:
   app.kubernetes.io/name: venafi-kubernetes-agent
   app.kubernetes.io/instance: release-name
@@ -8,6 +9,7 @@
 ---
 ConfigMap
 name: agent-config
+namespace: venafi
 labels:
   app.kubernetes.io/name: venafi-kubernetes-agent
   app.kubernetes.io/instance: release-name
@@ -168,6 +170,7 @@
 ---
 Deployment
 name: venafi-kubernetes-agent-release-name
+namespace: venafi
 labels:
   app.kubernetes.io/name: venafi-kubernetes-agent
   app.kubernetes.io/instance: release-name
```

Manual test **for the chart `jetstack-agent`**:

```bash
# First, on master:
git checkout master
helm package ./deploy/charts/jetstack-agent --version 0.0.0-master
# Second, on the PR:
gh pr checkout 526
helm package ./deploy/charts/jetstack-agent --version 0.0.0-pr
diff -u \
  <(helm template jetstack-agent-0.0.0-master.tgz -n venafi --set config.organisation=foo --set config.cluster=bar | grep -v "helm.sh/chart" | yq .kind,.metadata) \
  <(helm template jetstack-agent-0.0.0-pr.tgz -n venafi --set config.organisation=foo --set config.cluster=bar | grep -v "helm.sh/chart" | yq .kind,.metadata)
```

Result:

```diff
--- /dev/fd/13  2024-03-26 15:36:21
+++ /dev/fd/14  2024-03-26 15:36:21
@@ -1,5 +1,6 @@
 ServiceAccount
 name: jetstack-agent-release-name
+namespace: venafi
 labels:
   app.kubernetes.io/name: jetstack-agent
   app.kubernetes.io/instance: release-name
@@ -8,6 +9,7 @@
 ---
 ConfigMap
 name: agent-config
+namespace: venafi
 labels:
   app.kubernetes.io/name: jetstack-agent
   app.kubernetes.io/instance: release-name
@@ -158,6 +160,7 @@
 ---
 Deployment
 name: jetstack-agent-release-name
+namespace: venafi
 labels:
   app.kubernetes.io/name: jetstack-agent
   app.kubernetes.io/instance: release-name
```