### PR TITLE
feat(httpproxy): Update chart to support httproxy

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/Chart.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/Chart.yaml
@@ -3,5 +3,5 @@ name: venafi-kubernetes-agent
 description: |-
   The Venafi Kubernetes Agent connects your Kubernetes or Openshift cluster to the Venafi Control Plane.
 type: application
-version: 0.1.46
-appVersion: "v0.1.46"
+version: 0.1.47
+appVersion: "v0.1.47"

--- a/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
@@ -32,13 +32,20 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if  eq .Values.authentication.type "token" }}
+          {{- if or .Values.http_proxy .Values.https_proxy .Values.no_proxy }}
           env:
-            - name: API_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "agent-credentials" .Values.authentication.secretName }}
-                  key: {{ default "apitoken" .Values.authentication.secretKey }}
+          {{- with .Values.http_proxy }}
+          - name: HTTP_PROXY
+            value: {{ . }}
+          {{- end }}
+          {{- with .Values.https_proxy }}
+          - name: HTTPS_PROXY
+            value: {{ . }}
+          {{- end }}
+          {{- with .Values.no_proxy }}
+          - name: NO_PROXY
+            value: {{ . }}
+          {{- end }}
           {{- end }}
           {{- if not (empty .Values.command) }}
           command:

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Defaults to only pull if not already present
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion
-  tag: "v0.1.45"
+  tag: "v0.1.47"
 
 # -- Specify image pull credentials if using a private registry
 # example: - name: my-pull-secret
@@ -40,6 +40,21 @@ podSecurityContext: {}
   # runAsUser: 1000
   # runAsGroup: 3000
   # fsGroup: 2000
+
+# Use these variables to configure the HTTP_PROXY environment variables.
+
+# Configures the HTTP_PROXY environment variable where a HTTP proxy is required.
+# +docs:property
+# http_proxy: "http://proxy:8080"
+
+# Configures the HTTPS_PROXY environment variable where a HTTP proxy is required.
+# +docs:property
+# https_proxy: "https://proxy:8080"
+
+# Configures the NO_PROXY environment variable where a HTTP proxy is required,
+# but certain domains should be excluded.
+# +docs:property
+# no_proxy: 127.0.0.1,localhost
 
 # -- Add Container specific SecurityContext settings to the container. Takes precedence over `podSecurityContext` when set. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
 securityContext:


### PR DESCRIPTION
Updates the venafi-kubernetes-agent helm chart to include the HTTPS_PROXY, HTTP_PROXY, NO_PROXY env vars.

<details><summary>with HTTPS_PROXY value </summary>

```
# Source: venafi-kubernetes-agent/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: venafi-kubernetes-agent-release-name
  namespace: default
  labels:
    helm.sh/chart: venafi-kubernetes-agent-0.1.47
    app.kubernetes.io/name: venafi-kubernetes-agent
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.1.47"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: venafi-kubernetes-agent
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: venafi-kubernetes-agent
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: venafi-kubernetes-agent-release-name
      securityContext:
        {}
      containers:
        - name: venafi-kubernetes-agent
          securityContext:
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          image: "registry.venafi.cloud/venafi-agent/venafi-agent:v0.1.47"
          imagePullPolicy: IfNotPresent
          env:
          - name: HTTPS_PROXY
            value: https://proxy:8080
          args:
            - "agent"
            - "-c"
            - "/etc/venafi/agent/config/config.yaml"
            - "--client-id"
            - ""
            - "-p"
            - "0h1m0s"
            - --venafi-cloud
          resources:
            limits:
              cpu: 500m
              memory: 500Mi
            requests:
              cpu: 200m
              memory: 200Mi
          volumeMounts:
            - name: config
              mountPath: "/etc/venafi/agent/config"
              readOnly: true
            - name: credentials
              mountPath: "/etc/venafi/agent/key"
              readOnly: true
      volumes:
        - name: config
          configMap:
            name: agent-config
            optional: false
        - name: credentials
          secret:
            secretName: agent-credentials
            optional: false
```
</details>

<details><summary>with HTTP_PROXY value </summary>

```
# Source: venafi-kubernetes-agent/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: venafi-kubernetes-agent-release-name
  namespace: default
  labels:
    helm.sh/chart: venafi-kubernetes-agent-0.1.47
    app.kubernetes.io/name: venafi-kubernetes-agent
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.1.47"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: venafi-kubernetes-agent
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: venafi-kubernetes-agent
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: venafi-kubernetes-agent-release-name
      securityContext:
        {}
      containers:
        - name: venafi-kubernetes-agent
          securityContext:
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          image: "registry.venafi.cloud/venafi-agent/venafi-agent:v0.1.47"
          imagePullPolicy: IfNotPresent
          env:
          - name: HTTP_PROXY
            value: http://proxy:8080
          args:
            - "agent"
            - "-c"
            - "/etc/venafi/agent/config/config.yaml"
            - "--client-id"
            - ""
            - "-p"
            - "0h1m0s"
            - --venafi-cloud
          resources:
            limits:
              cpu: 500m
              memory: 500Mi
            requests:
              cpu: 200m
              memory: 200Mi
          volumeMounts:
            - name: config
              mountPath: "/etc/venafi/agent/config"
              readOnly: true
            - name: credentials
              mountPath: "/etc/venafi/agent/key"
              readOnly: true
      volumes:
        - name: config
          configMap:
            name: agent-config
            optional: false
        - name: credentials
          secret:
            secretName: agent-credentials
            optional: false
```

</details>


<details><summary>with NO_PROXY values </summary>

```
# Source: venafi-kubernetes-agent/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: venafi-kubernetes-agent-release-name
  namespace: default
  labels:
    helm.sh/chart: venafi-kubernetes-agent-0.1.47
    app.kubernetes.io/name: venafi-kubernetes-agent
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.1.47"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: venafi-kubernetes-agent
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: venafi-kubernetes-agent
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: venafi-kubernetes-agent-release-name
      securityContext:
        {}
      containers:
        - name: venafi-kubernetes-agent
          securityContext:
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          image: "registry.venafi.cloud/venafi-agent/venafi-agent:v0.1.47"
          imagePullPolicy: IfNotPresent
          env:
          - name: NO_PROXY
            value: 127.0.0.1,localhost
          args:
            - "agent"
            - "-c"
            - "/etc/venafi/agent/config/config.yaml"
            - "--client-id"
            - ""
            - "-p"
            - "0h1m0s"
            - --venafi-cloud
          resources:
            limits:
              cpu: 500m
              memory: 500Mi
            requests:
              cpu: 200m
              memory: 200Mi
          volumeMounts:
            - name: config
              mountPath: "/etc/venafi/agent/config"
              readOnly: true
            - name: credentials
              mountPath: "/etc/venafi/agent/key"
              readOnly: true
      volumes:
        - name: config
          configMap:
            name: agent-config
            optional: false
        - name: credentials
          secret:
            secretName: agent-credentials
            optional: false
```
</details>