### PR TITLE
VC-32931: Gather Istio's secret keys

### DIFF
--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -52,17 +52,22 @@ func getObject(version, kind, name, namespace string, withManagedFields bool) *u
 	}
 }
 
-func getSecret(name, namespace string, data map[string]interface{}, isTLS bool, withLastApplied bool) *unstructured.Unstructured {
+type secretType string
+
+var (
+	opaque secretType = "Opaque"
+	tls    secretType = "kubernetes.io/tls"
+	istio  secretType = "istio.io/ca-root"
+)
+
+func getSecret(name, namespace string, data map[string]interface{}, t secretType, withLastApplied bool) *unstructured.Unstructured {
 	object := getObject("v1", "Secret", name, namespace, false)
 
 	if data != nil {
 		object.Object["data"] = data
 	}
 
-	object.Object["type"] = "Opaque"
-	if isTLS {
-		object.Object["type"] = "kubernetes.io/tls"
-	}
+	object.Object["type"] = string(t)
 
 	metadata, _ := object.Object["metadata"].(map[string]interface{})
 	annotations := make(map[string]interface{})
@@ -510,17 +515,17 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			addObjects: []runtime.Object{
 				getSecret("testsecret", "testns1", map[string]interface{}{
 					"secretKey": "secretValue",
-				}, false, true),
+				}, opaque, true),
 				getSecret("anothertestsecret", "testns2", map[string]interface{}{
 					"secretNumber": "12345",
-				}, false, true),
+				}, opaque, true),
 			},
 			expected: []*api.GatheredResource{
 				{
-					Resource: getSecret("testsecret", "testns1", nil, false, false),
+					Resource: getSecret("testsecret", "testns1", nil, opaque, false),
 				},
 				{
-					Resource: getSecret("anothertestsecret", "testns2", nil, false, false),
+					Resource: getSecret("anothertestsecret", "testns2", nil, opaque, false),
 				},
 			},
 		},
@@ -534,11 +539,11 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 					"tls.key": "secretValue",
 					"tls.crt": "value",
 					"ca.crt":  "value",
-				}, true, true),
+				}, tls, true),
 				getSecret("anothertestsecret", "testns2", map[string]interface{}{
 					"example.key": "secretValue",
 					"example.crt": "value",
-				}, true, true),
+				}, tls, true),
 			},
 			expected: []*api.GatheredResource{
 				{
@@ -546,11 +551,43 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 					Resource: getSecret("testsecret", "testns1", map[string]interface{}{
 						"tls.crt": "value",
 						"ca.crt":  "value",
-					}, true, false),
+					}, tls, false),
 				},
 				{
 					// all other keys removed
-					Resource: getSecret("anothertestsecret", "testns2", nil, true, false),
+					Resource: getSecret("anothertestsecret", "testns2", nil, tls, false),
+				},
+			},
+		},
+		"Secret of type istio.io/ca-root should have crts and not keys": {
+			config: ConfigDynamic{
+				IncludeNamespaces:    []string{""},
+				GroupVersionResource: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+			},
+			addObjects: []runtime.Object{
+				getSecret("cacerts", "testns1", map[string]interface{}{
+					"root-cert.pem":  "cert",
+					"ca-cert.pem":    "cert",
+					"ca-key.pem":     "privatekey",
+					"cert-chain.pem": "cert",
+				}, opaque, true),
+				getSecret("istio-ca-secret", "testns2", map[string]interface{}{
+					"ca-cert.pem": "cert",
+					"ca-key.pem":  "privatekey",
+				}, istio, true),
+			},
+			expected: []*api.GatheredResource{
+				{
+					Resource: getSecret("cacerts", "testns1", map[string]interface{}{
+						"root-cert.pem":  "cert",
+						"ca-cert.pem":    "cert",
+						"cert-chain.pem": "cert",
+					}, opaque, false),
+				},
+				{
+					Resource: getSecret("istio-ca-secret", "testns2", map[string]interface{}{
+						"ca-cert.pem": "cert",
+					}, istio, false),
 				},
 			},
 		},

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -23,6 +23,13 @@ var SecretSelectedFields = []string{
 	"type",
 	"/data/tls.crt",
 	"/data/ca.crt",
+
+	// The following keys correspond to the standard keys expected by Istio
+	// Citadel to load a custom CA certificate. The secret types may be
+	// "istio.io/ca-root" or "generic".
+	"/data/ca-cert.pem",
+	"/data/cert-chain.pem",
+	"/data/root-cert.pem",
 }
 
 // RouteSelectedFields is the list of fields sent from OpenShift Route objects to the


### PR DESCRIPTION
**Ref:** [VC-32931](https://venafi.atlassian.net/browse/VC-32931)

Istio can be operated using a self-signed CA (with the secret `istio-ca-secret`) or using the Plugin CA with the secret `cacerts`. Both these secrets use non-standard keys unknown to the agent.

I've detailed what the contents of these two secrets are in https://venafi.atlassian.net/wiki/spaces/~862991627/pages/2429878323/VC-32931+Agent+to+capture+Istio+CA+info+and+send+to+cloud.

I'm not sure what tests are needed here, I'd need help on that.