### PR TITLE
[VC-32659] Remove the default CPU limit

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -166,7 +166,7 @@ You should see the following events for your service account:
 | podDisruptionBudget.enabled | bool | `false` | Enable or disable the PodDisruptionBudget resource, which helps prevent downtime during voluntary disruptions such as during a Node upgrade. |
 | podSecurityContext | object | `{}` | Optional Pod (all containers) `SecurityContext` options, see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod. |
 | replicaCount | int | `1` | default replicas, do not scale up |
-| resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"200m","memory":"200Mi"}}` | Set custom resourcing settings for the pod. You may not want this if you intend to use a Vertical Pod Autoscaler. |
+| resources | object | `{"limits":{"memory":"500Mi"},"requests":{"cpu":"200m","memory":"200Mi"}}` | Set resource requests and limits for the pod.  Read [Venafi Kubernetes components deployment best practices](https://docs.venafi.cloud/vaas/k8s-components/c-k8s-components-best-practice/#scaling) to learn how to choose suitable CPU and memory resource requests and limits. |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | Add Container specific SecurityContext settings to the container. Takes precedence over `podSecurityContext` when set. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container |
 | serviceAccount.annotations | object | `{}` | Annotations YAML to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -65,14 +65,16 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
-# -- Set custom resourcing settings for the pod. You may not want this if you intend to use a Vertical Pod Autoscaler.
+# -- Set resource requests and limits for the pod.
+#
+# Read [Venafi Kubernetes components deployment best practices](https://docs.venafi.cloud/vaas/k8s-components/c-k8s-components-best-practice/#scaling)
+# to learn how to choose suitable CPU and memory resource requests and limits.
 resources:
   requests:
     memory: 200Mi
     cpu: 200m
   limits:
     memory: 500Mi
-    cpu: 500m
 
 # -- Embed YAML for nodeSelector settings, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
 nodeSelector: {}


### PR DESCRIPTION
In https://docs.venafi.cloud/vaas/k8s-components/c-k8s-components-best-practice/#cpu we say:
> Read [Stop Using CPU Limits on Kubernetes](https://home.robusta.dev/blog/stop-using-cpu-limits), to learn why the best practice is to set CPU requests, but not limits.

So I've removed the default CPU limit from the chart values for venafi-kubernetes-agent.

I have not changed the `jetstack-agent` charts, because I think it is now considered legacy.

I also removed the note about using vertical pod autoscaler, because it seems irrelevant. We don't mention VPA in the documentation or in the other charts AFAIK.

