### PR TITLE
feat: enable volumes and volumeMounts to be passed to the jetstack-agent deployment

### DIFF
--- a/deploy/charts/jetstack-agent/README.md
+++ b/deploy/charts/jetstack-agent/README.md
@@ -133,12 +133,13 @@ kubectl logs -n jetstack-secure $(kubectl get pod -n jetstack-secure -l app.kube
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| authentication | object | `{"createSecret":false,"secretKey":"credentials.json","secretName":"agent-credentials","secretValue":"","type":"file"}` | Authentication section for the agent |
 | authentication.createSecret | bool | `false` | Reccomend that you do not use this and instead creat the credential secret outside of helm |
 | authentication.secretKey | string | `"credentials.json"` | Key name in secret |
 | authentication.secretName | string | `"agent-credentials"` | Name of the secret containing agent credentials.json |
 | authentication.secretValue | string | `""` | Base64 encoded value from Jetstack Secure Dashboard - only required when createSecret is true |
 | authentication.type | string | `"file"` | Type can be "file"/"token" determining how the agent should authenticate the to the backend |
-| command | list | `[]` |  |
+| command | list | `[]` | Override the jetstack-agent entrypoint with command list |
 | config | object | `{"cluster":"","dataGatherers":{"custom":[],"default":true},"organisation":"","override":{"config":null,"configmap":{"key":null,"name":null},"enabled":false},"period":"0h1m0s","server":"https://platform.jetstack.io"}` | Configuration section for the Jetstack Agent itself |
 | config.cluster | string | `""` | REQUIRED - Your Jetstack Secure Cluster Name |
 | config.dataGatherers | object | `{"custom":[],"default":true}` | Configure data that is gathered from your cluster, for full details see https://platform.jetstack.io/documentation/configuration/jetstack-agent/configuration |
@@ -151,7 +152,7 @@ kubectl logs -n jetstack-secure $(kubectl get pod -n jetstack-secure -l app.kube
 | config.override.enabled | bool | `false` | Override disabled by default |
 | config.period | string | `"0h1m0s"` | Send data back to the platform every minute unless changed |
 | config.server | string | `"https://platform.jetstack.io"` | Overrides the server if using a proxy between agent and Jetstack Secure |
-| extraArgs | list | `[]` |  |
+| extraArgs | list | `[]` | Add additional arguments to the  |
 | fullnameOverride | string | `""` | Helm default setting, use this to shorten install name |
 | image.pullPolicy | string | `"IfNotPresent"` | Defaults to only pull if not already present |
 | image.repository | string | `"quay.io/jetstack/preflight"` | Default to Open Source image repository |
@@ -174,4 +175,6 @@ kubectl logs -n jetstack-secure $(kubectl get pod -n jetstack-secure -l app.kube
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created @default true |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |
+| volumeMounts | list | `[]` | Additional volume mounts to add to the jetstack-agent container. |
+| volumes | list | `[]` | Additional volumes to add to the jetstack-agent pod. |
 

--- a/deploy/charts/jetstack-agent/README.md
+++ b/deploy/charts/jetstack-agent/README.md
@@ -139,7 +139,7 @@ kubectl logs -n jetstack-secure $(kubectl get pod -n jetstack-secure -l app.kube
 | authentication.secretName | string | `"agent-credentials"` | Name of the secret containing agent credentials.json |
 | authentication.secretValue | string | `""` | Base64 encoded value from Jetstack Secure Dashboard - only required when createSecret is true |
 | authentication.type | string | `"file"` | Type can be "file"/"token" determining how the agent should authenticate the to the backend |
-| command | list | `[]` | Override the jetstack-agent entrypoint with command list |
+| command | list | `[]` | Override the jetstack-agent entrypoint with specified command. |
 | config | object | `{"cluster":"","dataGatherers":{"custom":[],"default":true},"organisation":"","override":{"config":null,"configmap":{"key":null,"name":null},"enabled":false},"period":"0h1m0s","server":"https://platform.jetstack.io"}` | Configuration section for the Jetstack Agent itself |
 | config.cluster | string | `""` | REQUIRED - Your Jetstack Secure Cluster Name |
 | config.dataGatherers | object | `{"custom":[],"default":true}` | Configure data that is gathered from your cluster, for full details see https://platform.jetstack.io/documentation/configuration/jetstack-agent/configuration |
@@ -152,7 +152,7 @@ kubectl logs -n jetstack-secure $(kubectl get pod -n jetstack-secure -l app.kube
 | config.override.enabled | bool | `false` | Override disabled by default |
 | config.period | string | `"0h1m0s"` | Send data back to the platform every minute unless changed |
 | config.server | string | `"https://platform.jetstack.io"` | Overrides the server if using a proxy between agent and Jetstack Secure |
-| extraArgs | list | `[]` | Add additional arguments to the  |
+| extraArgs | list | `[]` | Add additional arguments to the default `agent` command. |
 | fullnameOverride | string | `""` | Helm default setting, use this to shorten install name |
 | image.pullPolicy | string | `"IfNotPresent"` | Defaults to only pull if not already present |
 | image.repository | string | `"quay.io/jetstack/preflight"` | Default to Open Source image repository |

--- a/deploy/charts/jetstack-agent/templates/deployment.yaml
+++ b/deploy/charts/jetstack-agent/templates/deployment.yaml
@@ -75,6 +75,9 @@ spec:
               mountPath: "/etc/jetstack-secure/agent/credentials"
               readOnly: true
             {{- end }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -103,3 +106,6 @@ spec:
           secret:
             secretName: {{ default "agent-credentials" .Values.authentication.secretName }}
             optional: false
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deploy/charts/jetstack-agent/tests/deployment_test.yaml
+++ b/deploy/charts/jetstack-agent/tests/deployment_test.yaml
@@ -90,3 +90,27 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].command
           content: notpreflight
+
+  # Check the volumes and volumeMounts works correctly
+  - it: Volumes and VolumenMounts added correctly
+    set:
+      config.organisation: test_org
+      config.cluster: test_cluster
+    values:
+      - ./values/custom-volumes.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          # In template this comes after credentials and agent config volumeMounts
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name == "cabundle")]
+          value:
+            mountPath: /etc/ssl/certs/
+            name: cabundle
+            readOnly: true     
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "cabundle")].configmap
+          value:
+            defaultMode: 420
+            name: cabundle
+            optional: true

--- a/deploy/charts/jetstack-agent/tests/deployment_test.yaml
+++ b/deploy/charts/jetstack-agent/tests/deployment_test.yaml
@@ -92,7 +92,7 @@ tests:
           content: notpreflight
 
   # Check the volumes and volumeMounts works correctly
-  - it: Volumes and VolumenMounts added correctly
+  - it: Volumes and VolumeMounts added correctly
     set:
       config.organisation: test_org
       config.cluster: test_cluster

--- a/deploy/charts/jetstack-agent/tests/values/custom-volumes.yaml
+++ b/deploy/charts/jetstack-agent/tests/values/custom-volumes.yaml
@@ -1,0 +1,11 @@
+volumes:
+  - name: cabundle
+    configmap:
+      name: cabundle
+      optional: true
+      defaultMode: 0644
+
+volumeMounts:
+  - name: cabundle
+    readOnly: true
+    mountPath: /etc/ssl/certs/

--- a/deploy/charts/jetstack-agent/values.yaml
+++ b/deploy/charts/jetstack-agent/values.yaml
@@ -62,6 +62,19 @@ tolerations: []
 
 affinity: {}
 
+# -- Additional volumes to add to the jetstack-agent pod.
+volumes: []
+
+# -- Additional volume mounts to add to the jetstack-agent container.
+volumeMounts: []
+
+# -- Override the jetstack-agent entrypoint with command list
+command: []
+
+# -- Add additional arguments to the 
+extraArgs: []
+
+# -- Authentication section for the agent
 authentication:
   # -- Reccomend that you do not use this and instead creat the credential secret outside of helm
   createSecret: false 
@@ -73,9 +86,6 @@ authentication:
   secretKey: "credentials.json"
   # -- Base64 encoded value from Jetstack Secure Dashboard - only required when createSecret is true
   secretValue: ""
-
-command: []
-extraArgs: []
 
 # -- Configuration section for the Jetstack Agent itself
 config:

--- a/deploy/charts/jetstack-agent/values.yaml
+++ b/deploy/charts/jetstack-agent/values.yaml
@@ -68,10 +68,10 @@ volumes: []
 # -- Additional volume mounts to add to the jetstack-agent container.
 volumeMounts: []
 
-# -- Override the jetstack-agent entrypoint with command list
+# -- Override the jetstack-agent entrypoint with specified command.
 command: []
 
-# -- Add additional arguments to the 
+# -- Add additional arguments to the default `agent` command.
 extraArgs: []
 
 # -- Authentication section for the agent


### PR DESCRIPTION
I was working with a customer and needed to pass a configmap mount to the deployment.
This is not currently available in the chart.
This PR adds this capability in a generic way, similar to how it is done in the [cert-manager chart](https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml#L317-L321).

I have specifically not created a new release of the chart. I intend to do a simple followup PR to release 0.3.2.