### PR TITLE
[VC-34401] Add metrics settings to the Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ go run main.go echo
 The Jetstack-Secure agent exposes its metrics through a Prometheus server, on port 8081.
 The Prometheus server is disabled by default but can be enabled by passing the `--enable-metrics` flag to the agent binary.
 
+If you deploy the agent with Helm, using the venafi-kubernetes-agent Helm chart, the metrics server will be enabled by default, on port 8081.
+If you use the Prometheus Operator, you can use `--set metrics.podmonitor.enabled=true` to deploy a `PodMonitor` resource,
+which will add the venafi-kubernetes-agent metrics to your Prometheus server.
+
+The following metrics are collected:
+ * Go collector: via the [default registry](https://github.com/prometheus/client_golang/blob/34e02e282dc4a3cb55ca6441b489ec182e654d59/prometheus/registry.go#L60-L63) in Prometheus client_golang.
+ * Process collector: via the [default registry](https://github.com/prometheus/client_golang/blob/34e02e282dc4a3cb55ca6441b489ec182e654d59/prometheus/registry.go#L60-L63) in Prometheus client_golang.
+ * Agent metrics:
+  * `data_readings_upload_size`: Data readings upload size (in bytes) sent by the jscp in-cluster agent.
+
 ## Release Process
 
 The release process is semi-automated.

--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -159,6 +159,15 @@ You should see the following events for your service account:
 | image.repository | string | `"registry.venafi.cloud/venafi-agent/venafi-agent"` | Default to Open Source image repository |
 | image.tag | string | `"v0.1.48"` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` | Specify image pull credentials if using a private registry example: - name: my-pull-secret |
+| metrics.enabled | bool | `true` | Enable the metrics server. If false, the metrics server will be disabled and the other metrics fields below will be ignored. |
+| metrics.podmonitor.annotations | object | `{}` | Additional annotations to add to the PodMonitor. |
+| metrics.podmonitor.enabled | bool | `false` | Create a PodMonitor to add the metrics to Prometheus, if you are using Prometheus Operator. See https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor |
+| metrics.podmonitor.endpointAdditionalProperties | object | `{}` | EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.  For example:  endpointAdditionalProperties:   relabelings:   - action: replace     sourceLabels:     - __meta_kubernetes_pod_node_name     targetLabel: instance  |
+| metrics.podmonitor.honorLabels | bool | `false` | Keep labels from scraped data, overriding server-side labels. |
+| metrics.podmonitor.interval | string | `"60s"` | The interval to scrape metrics. |
+| metrics.podmonitor.labels | object | `{}` | Additional labels to add to the PodMonitor. |
+| metrics.podmonitor.prometheusInstance | string | `"default"` | Specifies the `prometheus` label on the created PodMonitor. This is used when different Prometheus instances have label selectors matching different PodMonitors. |
+| metrics.podmonitor.scrapeTimeout | string | `"30s"` | The timeout before a metrics scrape fails. |
 | nameOverride | string | `""` | Helm default setting to override release name, usually leave blank. |
 | nodeSelector | object | `{}` | Embed YAML for nodeSelector settings, see https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/ |
 | podAnnotations | object | `{}` | Additional YAML annotations to add the the pod. |
@@ -172,4 +181,6 @@ You should see the following events for your service account:
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If blank and `serviceAccount.create` is true, a name is generated using the fullname template of the release. |
 | tolerations | list | `[]` | Embed YAML for toleration settings, see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
+| volumeMounts | list | `[]` | Additional volume mounts to add to the Venafi Kubernetes Agent container. This is useful for mounting a custom CA bundle. Any PEM certificate mounted under /etc/ssl/certs will be loaded by the Venafi Kubernetes Agent. For example:      volumeMounts:       - name: cabundle         mountPath: /etc/ssl/certs/cabundle         subPath: cabundle         readOnly: true |
+| volumes | list | `[]` | Additional volumes to add to the Venafi Kubernetes Agent container. This is useful for mounting a custom CA bundle. For example:      volumes:       - name: cabundle         configMap:           name: cabundle           optional: false           defaultMode: 0644  In order to create the ConfigMap, you can use the following command:      kubectl create configmap cabundle \       --from-file=cabundle=./your/custom/ca/bundle.pem |
 

--- a/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
             - "-p"
             - "0h1m0s"
             - --venafi-cloud
+            {{- if .Values.metrics.enabled }}
+            - --enable-metrics
+            {{- end }}
             {{- range .Values.extraArgs }}
             - {{ . | quote }}
             {{- end }}
@@ -77,6 +80,11 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.metrics.enabled }}
+          ports:
+            - containerPort: 8081
+              name: http-metrics
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/venafi-kubernetes-agent/templates/podmonitor.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/podmonitor.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podmonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}
+{{- if .Values.metrics.podmonitor.namespace }}
+  namespace: {{ .Values.metrics.podmonitor.namespace }}
+{{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+    prometheus: {{ .Values.metrics.podmonitor.prometheusInstance }}
+    {{- with .Values.metrics.podmonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- with .Values.metrics.podmonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  jobLabel: {{ include "venafi-kubernetes-agent.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "venafi-kubernetes-agent.selectorLabels" . | nindent 6 }}
+{{- if .Values.metrics.podmonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+{{- end }}
+  podMetricsEndpoints:
+    - port: http-metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podmonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.podmonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.metrics.podmonitor.honorLabels }}
+      {{- with .Values.metrics.podmonitor.endpointAdditionalProperties }}
+      {{- toYaml . | nindent 4 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -2,6 +2,52 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+metrics:
+  # -- Enable the metrics server.
+  # If false, the metrics server will be disabled and the other metrics fields below will be ignored.
+  enabled: true
+  podmonitor:
+    # -- Create a PodMonitor to add the metrics to Prometheus, if you are using Prometheus Operator.
+    # See https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor
+    enabled: false
+
+    # -- The namespace that the pod monitor should live in.
+    # Defaults to the venafi-kubernetes-agent namespace.
+    # +docs:property
+    # namespace: venafi
+
+    # -- Specifies the `prometheus` label on the created PodMonitor.
+    # This is used when different Prometheus instances have label selectors
+    # matching different PodMonitors.
+    prometheusInstance: default
+
+    # -- The interval to scrape metrics.
+    interval: 60s
+
+    # -- The timeout before a metrics scrape fails.
+    scrapeTimeout: 30s
+
+    # -- Additional labels to add to the PodMonitor.
+    labels: {}
+
+    # -- Additional annotations to add to the PodMonitor.
+    annotations: {}
+
+    # -- Keep labels from scraped data, overriding server-side labels.
+    honorLabels: false
+
+    # -- EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.
+    #
+    # For example:
+    #  endpointAdditionalProperties:
+    #   relabelings:
+    #   - action: replace
+    #     sourceLabels:
+    #     - __meta_kubernetes_pod_node_name
+    #     targetLabel: instance
+    #
+    endpointAdditionalProperties: {}
+
 # -- default replicas, do not scale up
 replicaCount: 1
 


### PR DESCRIPTION
In https://github.com/jetstack/jetstack-secure/pull/341 @tfadeyi added a metrics server to the agent.
In this PR I've made the minimum viable changes to allow that metrics server to be queried by Prometheus,
when the agent is installed by Helm in a Kubernetes cluster.

* I have chosen to only update the venafi-kubernetes-agent chart, because I believe the jetstack-secure agent is deprecated / retired.
* I decided not to make the metrics server port configurable. In csi-driver and approver-policy etc it is configurable, to allow users to change it in case it clashes with some other sidecar container that might be injected in the pod. If it becomes necessary, we can make the port configurable in a followup PR.
* I decided not to add any E2E tests...because there weren't any existing tests to use as examples.

> 🔗 FYI I recently made similar changes to cert-manager/csi-driver
>  * https://github.com/cert-manager/csi-driver/pull/271

## Testing
 * Create cluster
```
kind create cluster
```

 * Install agent
```
helm upgrade venafi-kubernetes-agent ./deploy/charts/venafi-kubernetes-agent \
    --install \
    --create-namespace \
    --namespace venafi
```

* Fetch metrics directly
```sh
POD_NAME=$(kubectl get pod -n venafi -l app.kubernetes.io/instance=venafi-kubernetes-agent -o jsonpath='{ .items[0].metadata.name }')
kubectl get --raw "/api/v1/namespaces/venafi/pods/${POD_NAME}:8081/proxy/metrics" | grep HELP
```

```
...
# HELP go_info Information about the Go environment.
...
# HELP process_open_fds Number of open file descriptors.
...
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
```

* Install kube-prometheus-stack

```yaml
# values.kube-prometheus-stack.yaml
alertmanager:
  enabled: false

grafana:
  enabled: true

nodeExporter:
  enabled: false

# Enable discovery of all ServiceMonitor and PodMonitor resources
# https://github.com/prometheus-community/helm-charts/issues/1911#issuecomment-1106559031
prometheus:
  prometheusSpec:
    serviceMonitorSelectorNilUsesHelmValues: false
    podMonitorSelectorNilUsesHelmValues: false
```

```sh
helm upgrade -i default kube-prometheus-stack \
      --repo https://prometheus-community.github.io/helm-charts \
      --install \
      --namespace prometheus \
      --create-namespace \
      --values values.kube-prometheus-stack.yaml \
      --wait
```

* Enable the venafi-kubernetes-agent PodMonitor

```sh
helm upgrade venafi-kubernetes-agent ./deploy/charts/venafi-kubernetes-agent \
    --install \
    --create-namespace \
    --namespace venafi \
    --set metrics.podmonitor.enabled=true
```

* Connect to Grafana and import dashboards

```sh
kubectl port-forward -n prometheus deployments/default-grafana 3000
```
> http://localhost:3000/d/ypFZFgvmz/go-processes (username `admin`, password `prom-operator`)


## Example Dashboards

To import the dashboard, go to http://localhost:3000/dashboards and "New" → "Import", and paste the following dashboard URL and click "Load":

* https://grafana.com/grafana/dashboards/6671-go-processes/
<img width="960" alt="image" src="https://github.com/jetstack/jetstack-secure/assets/978965/e2ad7a37-c729-4a89-b82b-6e4b2f4eb22d">

