### PR TITLE
fix: runAsUser in yaml is unneeded as its set in the Dockerfile

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -109,7 +109,6 @@ securityContext:
     - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
-  runAsUser: 1000
 
 # -- Set resource requests and limits for the pod.
 #


### PR DESCRIPTION
This also fixes an issue in OpenShift where OpenShift wants you to use a certain range of UIDs that 1000 does not fall into:

```
.containers[0].runAsUser: Invalid value: 1000: must be in the ranges: [1000660000, 1000669999]
```

By not specifying an runAsUser in the yaml, OpenShift picks a appropriate UID for you:

```
$ kubectl get deployment venafi-kubernetes-agent | grep runAsUser
$ kubectl get pod venafi-kubernetes-agent-6b8f756ffb-rmb45 -o yaml | grep runAsUser
      runAsUser: 1000660000
```

Since the Dockerfile contains the USER directive this should have no effect on non OpenShift Kubernetes clusters.
