### PR TITLE
fix: Set master build pipeline to no use experimental cosign with env var

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - build-fix-provenance
     tags:
       - v*
 jobs:
@@ -98,6 +99,8 @@ jobs:
         command: generate
         subcommand: files
         arguments: --artifact-path mock
+      env:
+        COSIGN_EXPERIMENTAL: 0
     - name: Extract predicate
       run: jq '.predicate' provenance.json > predicate.json
     - name: Attest


### PR DESCRIPTION
Fixes #545 