### PR TITLE
Use our own logger instance instead of the standard logger

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"time"
 
 	"github.com/jetstack/preflight/pkg/agent"
+	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/jetstack/preflight/pkg/permissions"
 	"github.com/spf13/cobra"
 )
@@ -39,11 +39,11 @@ var agentRBACCmd = &cobra.Command{
 
 		b, err := ioutil.ReadFile(agent.ConfigFilePath)
 		if err != nil {
-			log.Fatalf("Failed to read config file: %s", err)
+			logs.Log.Fatalf("Failed to read config file: %s", err)
 		}
 		config, err := agent.ParseConfig(b, false)
 		if err != nil {
-			log.Fatalf("Failed to parse config file: %s", err)
+			logs.Log.Fatalf("Failed to parse config file: %s", err)
 		}
 
 		out := permissions.GenerateFullManifest(config.DataGatherers)

--- a/pkg/datagatherer/k8s/cache.go
+++ b/pkg/datagatherer/k8s/cache.go
@@ -1,10 +1,10 @@
 package k8s
 
 import (
-	"log"
 	"time"
 
 	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/pmylund/go-cache"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -40,7 +40,7 @@ func onAdd(obj interface{}, dgCache *cache.Cache) {
 		dgCache.Set(string(item.GetUID()), cacheObject, cache.DefaultExpiration)
 		return
 	}
-	log.Printf("could not %q resource to the cache, missing metadata/uid field", "add")
+	logs.Log.Printf("could not %q resource to the cache, missing metadata/uid field", "add")
 
 }
 
@@ -55,7 +55,7 @@ func onUpdate(old, new interface{}, dgCache *cache.Cache) {
 		return
 	}
 
-	log.Printf("could not %q resource to the cache, missing metadata/uid field", "update")
+	logs.Log.Printf("could not %q resource to the cache, missing metadata/uid field", "update")
 }
 
 // onDelete handles the informer deletion events, updating the object's properties with the deletion
@@ -69,7 +69,7 @@ func onDelete(obj interface{}, dgCache *cache.Cache) {
 		dgCache.Set(string(item.GetUID()), cacheObject, cache.DefaultExpiration)
 		return
 	}
-	log.Printf("could not %q resource to the cache, missing metadata/uid field", "delete")
+	logs.Log.Printf("could not %q resource to the cache, missing metadata/uid field", "delete")
 }
 
 // creates a new updated instance of a cache object, with the resource

--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -3,10 +3,10 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
+	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/pkg/errors"
 	"github.com/pmylund/go-cache"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -267,9 +267,9 @@ func (g *DataGathererDynamic) Run(stopCh <-chan struct{}) error {
 	// attach WatchErrorHandler, it needs to be set before starting an informer
 	err := g.informer.SetWatchErrorHandler(func(r *k8scache.Reflector, err error) {
 		if strings.Contains(fmt.Sprintf("%s", err), "the server could not find the requested resource") {
-			log.Printf("server missing resource for datagatherer of %q ", g.groupVersionResource)
+			logs.Log.Printf("server missing resource for datagatherer of %q ", g.groupVersionResource)
 		} else {
-			log.Printf("datagatherer informer for %q has failed and is backing off due to error: %s", g.groupVersionResource, err)
+			logs.Log.Printf("datagatherer informer for %q has failed and is backing off due to error: %s", g.groupVersionResource, err)
 		}
 	})
 	if err != nil {

--- a/pkg/echo/echo.go
+++ b/pkg/echo/echo.go
@@ -3,11 +3,11 @@ package echo
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/fatih/color"
 	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +20,7 @@ func Echo(cmd *cobra.Command, args []string) {
 	fmt.Println("Listening to requests at ", EchoListen)
 	err := http.ListenAndServe(EchoListen, nil)
 	if err != nil {
-		log.Fatal(err)
+		logs.Log.Fatal(err)
 	}
 }
 

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -1,0 +1,8 @@
+package logs
+
+import (
+	"log"
+	"os"
+)
+
+var Log = log.New(os.Stderr, "", log.LstdFlags)


### PR DESCRIPTION
Ref: [VC-35375](https://venafi.atlassian.net/browse/VC-35375 "AGENT: Fix the logs that say VCert...")

This prevents issues caused by external libraries which reconfigure the standard logger.

For example, in https://github.com/jetstack/jetstack-secure/pull/552, we saw that all log messages were prefixed with "vCert: ".

[VC-35375]: https://venafi.atlassian.net/browse/VC-35375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ