### PR TITLE
Feedback from #552

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -70,14 +70,14 @@ jobs:
       packages: write
       id-token: write
     steps:
-    - uses: webfactory/ssh-agent@v0.9.0
-      with:
-        ssh-private-key: ${{ secrets.DEPLOY_KEY_READ_VENAFI_CONNECTION_LIB }}
     - name: Install Tools
       # Installing 'bash' because it's required by the 'cosign-installer' action
       # and 'coreutils' because the 'slsa-provenance-action' requires a version
       # of 'base64' that supports the -w flag.
       run: apk add --update make git jq rsync curl bash coreutils go
+    - uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.DEPLOY_KEY_READ_VENAFI_CONNECTION_LIB }}
     - name: Adding github workspace as safe directory
       # See issue https://github.com/actions/checkout/issues/760
       run: git config --global --add safe.directory $GITHUB_WORKSPACE

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"net/url"
@@ -302,7 +301,7 @@ func getConfiguration() (Config, client.Client) {
 	if venConnMode && InstallNS == "" {
 		InstallNS, err = getInClusterNamespace()
 		if err != nil {
-			log.Fatalf("could not guess which namespace the agent is running in: %s", err)
+			logs.Log.Fatalf("could not guess which namespace the agent is running in: %s", err)
 		}
 	}
 	if venConnMode && VenConnNS == "" {
@@ -323,7 +322,7 @@ func getConfiguration() (Config, client.Client) {
 		// the --venafi-connection mode of authentication doesn't need any
 		// secrets (or any other information for that matter) to be loaded from
 		// disk (using --credentials-path). Everything is passed as flags.
-		log.Println("Venafi Connection mode was specified, using Venafi Connection authentication.")
+		logs.Log.Println("Venafi Connection mode was specified, using Venafi Connection authentication.")
 
 		// The venafi-cloud.upload_path was initially meant to let users
 		// configure HTTP proxies, but it has never been used since HTTP proxies
@@ -331,7 +330,7 @@ func getConfiguration() (Config, client.Client) {
 		// value with the new --venafi-connection flag, and this field is simply
 		// ignored.
 		if config.VenafiCloud != nil && config.VenafiCloud.UploadPath != "" {
-			log.Printf(`ignoring venafi-cloud.upload_path. In Venafi Connection mode, this field is not needed.`)
+			logs.Log.Printf(`ignoring venafi-cloud.upload_path. In Venafi Connection mode, this field is not needed.`)
 		}
 
 		// Regarding venafi-cloud.uploader_id, we found that it doesn't do
@@ -340,12 +339,12 @@ func getConfiguration() (Config, client.Client) {
 		// set in the config file, and set it to an arbitrary value in the
 		// client since it doesn't matter.
 		if config.VenafiCloud.UploaderID != "" {
-			log.Printf(`ignoring venafi-cloud.uploader_id. In Venafi Connection mode, this field is not needed.`)
+			logs.Log.Printf(`ignoring venafi-cloud.uploader_id. In Venafi Connection mode, this field is not needed.`)
 		}
 
 		cfg, err := loadRESTConfig("")
 		if err != nil {
-			log.Fatalf("failed to load kubeconfig: %v", err)
+			logs.Log.Fatalf("failed to load kubeconfig: %v", err)
 		}
 
 		preflightClient, err = client.NewVenConnClient(cfg, agentMetadata, InstallNS, VenConnName, VenConnNS, nil)

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -1,0 +1,35 @@
+package kubeconfig
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// LoadRESTConfig loads the kube config from the provided path. If the path is
+// empty, the kube config will be loaded from KUBECONFIG, and if KUBECONFIG
+// isn't set, the in-cluster config will be used.
+func LoadRESTConfig(path string) (*rest.Config, error) {
+	switch path {
+	// If the kubeconfig path is not provided, use the default loading rules
+	// so we read the regular KUBECONFIG variable or create a non-interactive
+	// client for agents running in cluster
+	case "":
+		loadingrules := clientcmd.NewDefaultClientConfigLoadingRules()
+		cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			loadingrules, &clientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return cfg, nil
+	// Otherwise use the explicitly named kubeconfig file.
+	default:
+		cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+			&clientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return cfg, nil
+	}
+}


### PR DESCRIPTION
This is a follow-up PR to #552. I had forgotten to push these few commits before clicking "Merge"... 😨

- The first commit fixes a few `log` that should have been `logs.Log`.
- The second is about the tests: it moves the Go objects to inline YAML manifests for the RBAC and Secrets objects with the aim of making the tests a little more readable as well as making the task of comparing the inline YAML with the Helm chart easier.
- The third commit deduplicates the `loadRESTConfig` func (suggested in Richard's [comment](https://github.com/jetstack/jetstack-secure/pull/552#discussion_r1727089923)).
- Fourth commit fixes the CI on the master branch. CI is failing with "`/bin/sh: git: not found`". The issue is that `git` is missing when the GitHub Action "ssh-agent" runs. Example of failure: https://github.com/jetstack/jetstack-secure/actions/runs/10509465707/job/29115732869