### PR TITLE
Leftover processes after running `make test`

### DIFF
--- a/pkg/client/client_venconn_test.go
+++ b/pkg/client/client_venconn_test.go
@@ -346,14 +346,14 @@ func startEnvtest(t testing.TB) (_ *envtest.Environment, _ *rest.Config, kclient
 		ErrorIfCRDPathMissing: true,
 		CRDDirectoryPaths:     []string{"../../deploy/charts/venafi-kubernetes-agent/crd_bases/jetstack.io_venaficonnections.yaml"},
 	}
-	restconf, err := envtest.Start()
-	require.NoError(t, err)
 
+	restconf, err := envtest.Start()
 	t.Cleanup(func() {
 		t.Log("Waiting for envtest to exit")
-		err = envtest.Stop()
-		require.NoError(t, err)
+		e := envtest.Stop()
+		require.NoError(t, e)
 	})
+	require.NoError(t, err)
 
 	sch := runtime.NewScheme()
 	_ = v1alpha1.AddToScheme(sch)

--- a/pkg/client/client_venconn_test.go
+++ b/pkg/client/client_venconn_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -334,6 +335,13 @@ func fakeTPP(t testing.TB) (*httptest.Server, *x509.Certificate) {
 //
 //	export KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
 func startEnvtest(t testing.TB) (_ *envtest.Environment, _ *rest.Config, kclient ctrlruntime.WithWatch) {
+	// If KUBEBUILDER_ASSETS isn't set, show a warning to the user.
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Fatalf("KUBEBUILDER_ASSETS isn't set. You can run this test using `make test`.\n" +
+			"But if you prefer not to use `make`, run these two commands first:\n" +
+			"    make _bin/tools/{kube-apiserver,etcd}\n" +
+			"    export KUBEBUILDER_ASSETS=$PWD/_bin/tools")
+	}
 	envtest := &envtest.Environment{
 		ErrorIfCRDPathMissing: true,
 		CRDDirectoryPaths:     []string{"../../deploy/charts/venafi-kubernetes-agent/crd_bases/jetstack.io_venaficonnections.yaml"},


### PR DESCRIPTION
Sometimes (for example when the CRD file isn't found), the test would stop immediately after envtest.Start, meaning that the t.Cleanup block wouldn't run and the two new processes would be left over after the test process would end.

Credit for identifying this bug and fixing goes to Richard Wall in ([1]).

[1]: https://github.com/jetstack/jetstack-secure/pull/560#issuecomment-2306678780

