### PR TITLE
Test secretless authentication on GKE

### DIFF
--- a/hack/e2e/application-team-1.yaml
+++ b/hack/e2e/application-team-1.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-1
+---
+apiVersion: policy.cert-manager.io/v1alpha1
+kind: CertificateRequestPolicy
+metadata:
+  name: team-1
+spec:
+  allowed:
+    commonName:
+      value: '*'
+    dnsNames:
+      values:
+      - '*'
+    subject:
+      countries:
+        values:
+        - '*'
+      localities:
+        values:
+        - '*'
+      organizationalUnits:
+        values:
+        - '*'
+      organizations:
+        values:
+        - '*'
+      postalCodes:
+        values:
+        - '*'
+      provinces:
+        values:
+        - '*'
+      serialNumber:
+        value: '*'
+      streetAddresses:
+        values:
+        - '*'
+    usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+  plugins:
+    venafi:
+      values:
+        venafiConnectionName: venafi-components
+        zone: ${VEN_ZONE}
+  selector:
+    issuerRef:
+      group: jetstack.io
+      kind: VenafiIssuer
+      name: venafi-cloud
+    namespace:
+      matchNames:
+      - team-1
+---
+apiVersion: jetstack.io/v1alpha1
+kind: VenafiIssuer
+metadata:
+  name: venafi-cloud
+  namespace: team-1
+spec:
+  certificateNameExpression: request.namespace + "_" + request.name
+  venafiConnectionName: venafi-components
+  venafiConnectionNamespace: venafi
+  zone: ${VEN_ZONE}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: app-0
+  namespace: team-1
+spec:
+  commonName: app-0.team-1
+  duration: 720h0m0s
+  renewBefore: 719h0m0s
+  issuerRef:
+    group: jetstack.io
+    kind: VenafiIssuer
+    name: venafi-cloud
+  privateKey:
+    algorithm: RSA
+    rotationPolicy: Always
+    size: 2048
+  revisionHistoryLimit: 1
+  secretName: app-0
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-policy:allow
+  namespace: team-1
+rules:
+  - apiGroups: ["policy.cert-manager.io"]
+    resources: ["certificaterequestpolicies"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-policy:allow
+  namespace: team-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-policy:allow
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/e2e/values.venafi-kubernetes-agent.yaml
+++ b/hack/e2e/values.venafi-kubernetes-agent.yaml
@@ -6,7 +6,3 @@ config:
 authentication:
   venafiConnection:
     enabled: true
-
-crds:
-  venafiConnection:
-    include: true

--- a/hack/e2e/venafi-components.yaml
+++ b/hack/e2e/venafi-components.yaml
@@ -1,40 +1,27 @@
-apiVersion: jetstack.io/v1alpha1
-kind: VenafiConnection
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: venafi-components
-spec:
-  vcp:
-    accessToken:
-    - secret:
-        name: venafi-credentials
-        fields: ["access-token"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-      name: get-venafi-credentials
+  name: venafi-components-create-token
 rules:
-    - apiGroups: [ "" ]
-      resources: [ "secrets" ]
-      verbs: [ "get" ]
-      resourceNames: [ "venafi-credentials" ]
+- apiGroups: [ "" ]
+  resources: [ "serviceaccounts/token" ]
+  verbs: [ "create" ]
+  resourceNames: [ "venafi-components" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: application-team-1-secret-rolebinding
+  name: venafi-components-create-token
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: get-venafi-credentials
+  name: venafi-components-create-token
 subjects:
 - kind: ServiceAccount
   name: venafi-connection
   namespace: venafi
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: venafi-credentials
-stringData:
-  access-token: ${accesstoken}


### PR DESCRIPTION
This modified script will create a GKE cluster and set up: venafi-enhanced-issuer, approver-policy-enterprise, and venafi-kubernetes-agent to authenticate to Venafi Control Plane using a Kubernetes ServiceAccount Token.

```console
$ ./hack/e2e/test.sh
...
2024/08/23 16:35:02 Venafi Connection mode was specified, using Venafi Connection authentication.
2024/08/23 16:35:02 ignoring venafi-cloud.upload_path. In Venafi Connection mode, this field is not needed.
2024/08/23 16:35:02 ignoring venafi-cloud.uploader_id. In Venafi Connection mode, this field is not needed.
2024/08/23 16:35:02 Prometheus was enabled.
Running prometheus server on port :8081
2024/08/23 16:36:13 Posting data to: https://api.venafi.cloud/
2024/08/23 16:36:13 retrying in 20.592925933s after error: post to server failed: while loading the VenafiConnection venafi/venafi-components: VenafiConnection.jetstack.io "venafi-components" not found
2024/08/23 16:36:34 Posting data to: https://api.venafi.cloud/
2024/08/23 16:36:34 retrying in 55.382780171s after error: post to server failed: while loading the VenafiConnection venafi/venafi-components: VenafiConnection.jetstack.io "venafi-components" not found
2024/08/23 16:37:29 Posting data to: https://api.venafi.cloud/
2024/08/23 16:37:31 Data sent successfully.
```

```console
$ kubectl get venaficonnection -n venafi -o yaml
...
  status:
    conditions:
    - lastTransitionTime: "2024-08-27T16:52:14Z"
      lastUpdateTime: "2024-08-28T16:28:22Z"
      message: d97b3a02ea4dbd895aa730df409d9a15011aab855d710d59822e852cb84fae64
      observedGeneration: 3
      reason: Generated a token
      status: "True"
      tokenValidUntil: "2024-08-28T16:43:22Z"
      type: VenafiKubernetesAgentReady
    - lastTransitionTime: "2024-08-28T11:14:55Z"
      lastUpdateTime: "2024-08-28T16:41:11Z"
      message: 9822840ae10e13e9a0a7f6a0d74c8e70a201892a0e1aef8268f4e9527945eb2e
      observedGeneration: 3
      reason: Generated a token
      status: "True"
      tokenValidUntil: "2024-08-28T16:56:11Z"
      type: VenafiEnhancedIssuerReady
    - lastTransitionTime: "2024-08-28T14:36:22Z"
      lastUpdateTime: "2024-08-28T16:27:34Z"
      message: 51f7b1e16e7a5ac9255d019e1cf50857ebe04f2eb78892d45e1cdc96e01aa87c
      observedGeneration: 3
      reason: Generated a token
      status: "True"
      tokenValidUntil: "2024-08-28T16:42:34Z"
      type: ApproverPolicyVenafiReady
```

Here are the corresponding events from the Venafi Control Plane event log
<img width="960" alt="image" src="https://github.com/user-attachments/assets/3cc32f5e-73eb-4254-a931-737325c90af9">


Ref: [VC-35374](https://venafi.atlassian.net/browse/VC-35374)

[VC-35374]: https://venafi.atlassian.net/browse/VC-35374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ