### PR TITLE
Helm: bump version to 1.0.0 and appVersion to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ The release process is semi-automated.
       The `v` prefix [breaks Helm OCI operations](https://github.com/helm/helm/issues/11107).
    1. Increment `appVersion` value in [Chart.yaml](deploy/charts/venafi-kubernetes-agent/Chart.yaml).
       Use a `v` prefix, to match the Docker image tag.
-   1. Increment the `image.tag` value in [values.yaml](deploy/charts/venafi-kubernetes-agent/values.yaml).
-      Use a `v` prefix.
    1. Commit the changes.
 1. Create a pull request and wait for it to be approved.
 1. Merge the branch.

--- a/deploy/charts/venafi-kubernetes-agent/Chart.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/Chart.yaml
@@ -3,5 +3,5 @@ name: venafi-kubernetes-agent
 description: |-
   The Venafi Kubernetes Agent connects your Kubernetes or Openshift cluster to the Venafi Control Plane.
 type: application
-version: 0.1.49
-appVersion: "v0.1.49"
+version: 1.0.0
+appVersion: "v1.0.0"


### PR DESCRIPTION
This commit belongs to the release process for v1.0.0.

I've removed an instruction from the release process as I've noticed that the `tag` is now commented out in the values.yaml file:

```yaml
image:
  # -- Overrides the image tag whose default is the chart appVersion
  # tag: "v0.0.0"
```