### PR TITLE
VC-36545: Collect the secret's labels

### DIFF
--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -15,6 +15,7 @@ var SecretSelectedFields = []string{
 	"kind",
 	"apiVersion",
 	"metadata.annotations",
+	"metadata.labels",
 	"metadata.name",
 	"metadata.namespace",
 	"metadata.ownerReferences",

--- a/pkg/testutil/undent.go
+++ b/pkg/testutil/undent.go
@@ -122,7 +122,7 @@ func Undent(s string) string {
 
 		// Case 1: we want the user to be able to omit some tabs or spaces in
 		// the last line for readability purposes.
-		case line == len(lineOffsets)-1 && s[last] != '\n' && isIndent(s[first:last]):
+		case line == len(lineOffsets)-1 && s[last] != '\n' && isIndent(s[first:last+1]):
 			lineStr = ""
 
 		// Case 2: we want the user to be able to omit the indentations for

--- a/pkg/testutil/undent_test.go
+++ b/pkg/testutil/undent_test.go
@@ -34,6 +34,7 @@ func Test_Undent(t *testing.T) {
 
 		bar
 	`, "foo\n\nbar\n"))
+	t.Run("bug fix: last char is not omitted", runTest_Undent("\t\t{\n\t\t    \"kind\": \"Secret\"\n\t\t}", "{\n    \"kind\": \"Secret\"\n}"))
 }
 
 func runTest_Undent(given, expected string) func(t *testing.T) {


### PR DESCRIPTION
Ref: [VC-36545](https://venafi.atlassian.net/browse/VC-36545 "Update the agent to collect labels from secrets")

This PR makes sure labels are being pushed for Secret resources.

**Note to the reviewer:** I took the liberty of rewriting the tests. The best approach would have been to write a minimal commit with the feature and test changes, and then refactor the tests... but since Olu would prefer this being shipped as part of 1.1.0, I chose not to bother trying to separate the changes from the test refactoring.

## Tests

The unit tests cover the changes, so I haven't proceeded with manual e2e tests.

[VC-36545]: https://venafi.atlassian.net/browse/VC-36545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ