### PR TITLE
VC-36351: Include namespaces as part of the resources to be collected

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -27,6 +27,12 @@ data:
         resource-type:
           resource: pods
           version: v1
+    - kind: "k8s-dynamic"
+      name: "k8s/namespaces"
+      config:
+        resource-type:
+          resource: namespaces
+          version: v1
     # gather services for pod readiness probe rules
     - kind: "k8s-dynamic"
       name: "k8s/services"


### PR DESCRIPTION
Ref: [VC-36351](https://venafi.atlassian.net/browse/VC-36351 "Update the agent configuration to collect k8s namespace resources")

This PR adds namespaces to the "dynamic" configuration of the Agent in the Helm chart.

## Manual Testing

There is no automated test for this change. Thus, I went ahead and manually tested the feature.

I've used the tenant https://ven-tlspk.venafi.cloud/. To access the API key, use the user `system.admin@tlspk.qa.venafi.io` and the password is visible in the page [Production Accounts](https://venafi.atlassian.net/wiki/spaces/CT/pages/2115404149) (private to Venafi). Then go to the settings and find the API key.

```sh
export APIKEY=...
```

I've then deployed the agent to a Kind cluster (create it first):

```sh
venctl iam service-account agent create --name "$USER temp" \
  --vcp-region US \
  --output json \
  --owning-team $(curl -sS https://api.venafi.cloud/v1/teams -H "tppl-api-key: $APIKEY" | jq '.teams[0].id') \
  --output-file /tmp/agent-credentials.json \
  --api-key $APIKEY
make oci-push-preflight oci_preflight_image_name=ttl.sh/mael/venafi-agent oci_preflight_image_tag=v0.0.0-dev oci_platforms=linux/arm64
make helm-chart oci_preflight_image_tag=v0.0.0-dev helm_chart_version=0.0.0-dev oci_preflight_image_name=ttl.sh/mael/venafi-agent
helm push _bin/scratch/image/venafi-kubernetes-agent-0.0.0-dev.tgz oci://ttl.sh/mael/charts
helm upgrade -i -n venafi --create-namespace venafi-kubernetes-agent oci://ttl.sh/mael/charts/venafi-kubernetes-agent --version 0.0.0-dev \
  --set config.clusterName="$USER temp" --set config.clientId="$(jq -r .private_key /tmp/agent-credentials.json)"
kubectl create secret generic -n venafi agent-credentials --from-literal=privatekey.pem="$(jq -r .private_key /tmp/agent-credentials.json)" \
  --dry-run=client -o yaml | kubectl apply -f -
```

Make sure to have `127.0.0.1 me` in your `/etc/hosts`.

Then, run mitmproxy with:

```sh
curl -L https://raw.githubusercontent.com/maelvls/kubectl-incluster/main/watch-stream.py >/tmp/watch-stream.py
mitmproxy --mode regular@9090 --ssl-insecure -s /tmp/watch-stream.py --set client_certs=$(kubectl incluster --print-client-cert >/tmp/me.pem && echo /tmp/me.pem)
```

Finally, run the agent with:

```sh
kubectl scale -n venafi deploy venafi-kubernetes-agent venafi-kubernetes-agent --replicas 0
go install github.com/maelvls/kubectl-incluster@latest
export HTTPS_PROXY=http://localhost:9090 KUBECONFIG=/tmp/kube && KUBECONFIG= HTTPS_PROXY= kubectl incluster --replace-ca-cert ~/.mitmproxy/mitmproxy-ca-cert.pem --sa=venafi/venafi-kubernetes-agent | sed 's|127.0.0.1|me|' >/tmp/kube
go run . agent -c <(kubectl get cm -n venafi agent-config -oyaml | yq '.data."config.yaml"') --client-id $(jq -r .client_id /tmp/agent-credentials.json) --private-key-path <(jq -r .private_key /tmp/agent-credentials.json)
```

The data being sent contains the namespaces:

```json
{
  "cluster_id": "mvalais temp",
  "data-gatherer": "k8s/namespaces",
  "timestamp": "2024-10-03T10:12:23+02:00",
  "data": {
    "items": [
      {
        "resource": {
          "apiVersion": "v1",
          "kind": "Namespace",
          "metadata": {
            "creationTimestamp": "2024-09-20T18:03:34Z",
            "labels": { "kubernetes.io/metadata.name": "kube-node-lease" },
            "name": "kube-node-lease",
            "resourceVersion": "33",
            "uid": "824544b7-d72c-4369-99fa-919268bbf02a"
          },
          "spec": { "finalizers": ["kubernetes"] },
          "status": { "phase": "Active" }
        }
      },
      {
        "resource": {
          "apiVersion": "v1",
          "kind": "Namespace",
          "metadata": {
            "creationTimestamp": "2024-09-20T18:03:34Z",
            "labels": { "kubernetes.io/metadata.name": "kube-public" },
            "name": "kube-public",
            "resourceVersion": "18",
            "uid": "3ce5adb2-d175-4019-a1f7-7caa64aa6d9f"
          },
          "spec": { "finalizers": ["kubernetes"] },
          "status": { "phase": "Active" }
        }
      },
      {
        "resource": {
          "apiVersion": "v1",
          "kind": "Namespace",
          "metadata": {
            "creationTimestamp": "2024-09-20T18:03:34Z",
            "labels": { "kubernetes.io/metadata.name": "kube-system" },
            "name": "kube-system",
            "resourceVersion": "9",
            "uid": "f1746db2-2a93-4791-a49c-f9a147bf0eab"
          },
          "spec": { "finalizers": ["kubernetes"] },
          "status": { "phase": "Active" }
        }
      },
      {
        "resource": {
          "apiVersion": "v1",
          "kind": "Namespace",
          "metadata": {
            "annotations": {},
            "creationTimestamp": "2024-09-20T18:03:38Z",
            "labels": { "kubernetes.io/metadata.name": "local-path-storage" },
            "name": "local-path-storage",
            "resourceVersion": "271",
            "uid": "b33f35ec-c3a1-472d-a774-75c00fee90b0"
          },
          "spec": { "finalizers": ["kubernetes"] },
          "status": { "phase": "Active" }
        }
      },
      {
        "resource": {
          "apiVersion": "v1",
          "kind": "Namespace",
          "metadata": {
            "creationTimestamp": "2024-09-30T14:43:57Z",
            "labels": {
              "kubernetes.io/metadata.name": "venafi",
              "name": "venafi"
            },
            "name": "venafi",
            "resourceVersion": "157839",
            "uid": "17daf841-4962-4388-baa4-278342ed50f8"
          },
          "spec": { "finalizers": ["kubernetes"] },
          "status": { "phase": "Active" }
        }
      },
      {
        "resource": {
          "apiVersion": "v1",
          "kind": "Namespace",
          "metadata": {
            "creationTimestamp": "2024-10-01T14:09:33Z",
            "labels": {
              "kubernetes.io/metadata.name": "ambassador",
              "name": "ambassador"
            },
            "name": "ambassador",
            "resourceVersion": "201695",
            "uid": "5f821e3a-58cb-4d73-85eb-e7bbe02ad38f"
          },
          "spec": { "finalizers": ["kubernetes"] },
          "status": { "phase": "Active" }
        }
      },
      {
        "resource": {
          "apiVersion": "v1",
          "kind": "Namespace",
          "metadata": {
            "creationTimestamp": "2024-09-20T18:03:34Z",
            "labels": { "kubernetes.io/metadata.name": "default" },
            "name": "default",
            "resourceVersion": "39",
            "uid": "320a0e25-9b58-4f7a-b6d3-349044239cec"
          },
          "spec": { "finalizers": ["kubernetes"] },
          "status": { "phase": "Active" }
        }
      }
    ]
  },
  "schema_version": "v2.0.0"
}
```

[VC-36545]: https://venafi.atlassian.net/browse/VC-36545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VC-36351]: https://venafi.atlassian.net/browse/VC-36351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ