### PR TITLE
VC-36589: include crds not working

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/crd_bases/crd.header-without-validations.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/crd_bases/crd.header-without-validations.yaml
@@ -1,6 +1,6 @@
 {{/* DO NOT EDIT. Use 'make generate-crds-venconn' to regenerate. */}}
 {{- if .Values.crds.venafiConnection.include }}
-{{- if not (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
+{{- if (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/charts/venafi-kubernetes-agent/crd_bases/jetstack.io_venaficonnections.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/crd_bases/jetstack.io_venaficonnections.yaml
@@ -1,3 +1,4 @@
+# DO NOT EDIT: Use 'make generate-crds-venconn' to regenerate.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.without-validations.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.without-validations.yaml
@@ -13,13 +13,6 @@ metadata:
   {{- end }}
   labels:
   {{- include "venafi-connection.labels" . | nindent 4 }}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
-  name: venaficonnections.jetstack.io
 spec:
   group: jetstack.io
   names:

--- a/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.yaml
@@ -13,13 +13,6 @@ metadata:
   {{- end }}
   labels:
   {{- include "venafi-connection.labels" . | nindent 4 }}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
-  name: venaficonnections.jetstack.io
 spec:
   group: jetstack.io
   names:

--- a/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.yaml
@@ -1,6 +1,6 @@
 {{/* DO NOT EDIT. Use 'make generate-crds-venconn' to regenerate. */}}
 {{- if .Values.crds.venafiConnection.include }}
-{{- if (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
+{{- if not (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
## Manual Tests

This bug was not caught by the existing manually-run e2e test (`./smoke-test.sh`) because the smoke test uses `venctl` to install the Agent, and `venctl` doesn't use `crds.venafiConnection.include=true`. It installs the venafi-connection Helm chart separately.

This bug does not affect any released version of Venafi Kubernetes Agent, so no worries. This new bug is a blocker for v1.1.0 as it breaks the instructions that are on the website (the ones that tell you to use --set `crds.venafiConnection.include`).

Coming across this type of bug makes me think that we should pause and work on [VC-35565](https://venafi.atlassian.net/browse/VC-35565 "AGENT: Automate the E2E smoke test"). Otherwise, we will keep shipping broken Helm charts.

## Manual Tests

I didn't know how/where to automate these tests, so I'm going to document what I have tested in this this PR.

### Test 1: `crds.venafiConnection.include=true` works

The validation fields are present as expected:

```console
$ helm template -n venafi venafi-kubernetes-agent deploy/charts/venafi-kubernetes-agent/ --show-only templates/venafi-connection-crd.yaml --set crds.venafiConnection.include=true | grep validation
                        x-kubernetes-validations:
                        x-kubernetes-validations:
                        x-kubernetes-validations:
                  x-kubernetes-validations:
                        x-kubernetes-validations:
                        x-kubernetes-validations:
                  x-kubernetes-validations:
              x-kubernetes-validations:
```

The CRD is installed correctly on Kubernetes 1.29:

```console
$ kind create cluster --image kindest/node:v1.29.2
$ helm template -n venafi venafi-kubernetes-agent deploy/charts/venafi-kubernetes-agent/ --set crds.venafiConnection.include=true
 | kubectl apply -f-
$ k get crd                                                        
NAME                            CREATED AT
venaficonnections.jetstack.io   2024-10-07T09:30:30Z
```

### Test 2: `crds.venafiConnection.include=true` + `crds.forceRemoveValidationAnnotations=true` removes the validation annotations on Kubernetes 1.29

On Kubernetes 1.29, CRD is printed and the validation fields aren't outputed:

```console
$ helm template -n venafi venafi-kubernetes-agent deploy/charts/venafi-kubernetes-agent/ --show-only templates/venafi-connection-crd.without-validations.yaml --set crds.venafiConnection.include=true --set crds.forceRemoveValidationAnnotations=true | grep -E 'validation|CustomResource'
# Source: venafi-kubernetes-agent/templates/venafi-connection-crd.without-validations.yaml
kind: CustomResourceDefinition
```

On Kubernetes 1.29, it installs correctly:

```console
$ kind create cluster --image kindest/node:v1.29.2
$ helm template -n venafi venafi-kubernetes-agent deploy/charts/venafi-kubernetes-agent/ --set crds.venafiConnection.include=true --set crds.forceRemoveValidationAnnotations=true
 | kubectl apply -f-
$ k get crd
NAME                            CREATED AT
venaficonnections.jetstack.io   2024-10-07T09:43:43Z
```



### Test 3: `crds.venafiConnection.include=true` removes the validation annotations on Kubernetes 1.24

It installs correctly on Kubernetes 1.24:

```console
$ kind create cluster --image kindest/node:v1.24.4 --name v1.24.4
$ helm template -n venafi venafi-kubernetes-agent deploy/charts/venafi-kubernetes-agent/ --set crds.venafiConnection.include=true | kubectl apply -f-
customresourcedefinition.apiextensions.k8s.io/venaficonnections.jetstack.io configured
```