### PR TITLE
VC-35568: Feature: Send errors to the pod's event to increase visibility

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: 8081

--- a/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
@@ -102,6 +102,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.uid
+          - name: POD_NODE
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: 8081

--- a/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
@@ -89,6 +89,15 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: 8081

--- a/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
@@ -11,14 +11,14 @@ rules:
     verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "venafi-kubernetes-agent.fullname" . }}-event-emitted
   labels:
     {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "venafi-kubernetes-agent.fullname" . }}-event-emitted
 subjects:
   - kind: ServiceAccount

--- a/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
@@ -1,5 +1,31 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-event-emitted
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-event-emitted
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-event-emitted
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "venafi-kubernetes-agent.fullname" . }}-cluster-viewer

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -230,7 +230,7 @@ func newEventf(installNS string) (Eventf, error) {
 		}
 		broadcaster := record.NewBroadcaster()
 		broadcaster.StartRecordingToSink(&clientgocorev1.EventSinkImpl{Interface: eventClient.CoreV1().Events(installNS)})
-		eventRec := broadcaster.NewRecorder(scheme, corev1.EventSource{})
+		eventRec := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: "venafi-kubernetes-agent", Host: os.Getenv("POD_NODE")})
 		eventf = func(eventType, reason, msg string, args ...interface{}) {
 			eventRec.Eventf(&corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: installNS, UID: types.UID(os.Getenv("POD_UID"))}}, eventType, reason, msg, args...)
 		}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -18,11 +18,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgocorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/client"
 	"github.com/jetstack/preflight/pkg/datagatherer"
+	"github.com/jetstack/preflight/pkg/kubeconfig"
 	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/jetstack/preflight/pkg/version"
 
@@ -115,6 +122,13 @@ func Run(cmd *cobra.Command, args []string) {
 		}()
 	}
 
+	// To help users notice issues with the agent, we show the error messages in
+	// the agent pod's events.
+	eventf, err := newEventf(config.InstallNS)
+	if err != nil {
+		logs.Log.Fatalf("failed to create event recorder: %v", err)
+	}
+
 	dataGatherers := map[string]datagatherer.DataGatherer{}
 	group, gctx := errgroup.WithContext(ctx)
 
@@ -180,7 +194,7 @@ func Run(cmd *cobra.Command, args []string) {
 	// configured output using data in datagatherer caches or refreshing from
 	// APIs each cycle depending on datagatherer implementation
 	for {
-		gatherAndOutputData(config, preflightClient, dataGatherers)
+		gatherAndOutputData(eventf, config, preflightClient, dataGatherers)
 
 		if config.OneShot {
 			break
@@ -190,7 +204,44 @@ func Run(cmd *cobra.Command, args []string) {
 	}
 }
 
-func gatherAndOutputData(config CombinedConfig, preflightClient client.Client, dataGatherers map[string]datagatherer.DataGatherer) {
+// Creates an event recorder for the agent's Pod object. Expects the env var
+// POD_NAME to contain the pod name. Note that the RBAC rule allowing sending
+// events is attached to the pod's service account, not the impersonated service
+// account (venafi-connection).
+func newEventf(installNS string) (Eventf, error) {
+	restcfg, err := kubeconfig.LoadRESTConfig("")
+	if err != nil {
+		logs.Log.Fatalf("failed to load kubeconfig: %v", err)
+	}
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	var eventf Eventf
+	if os.Getenv("POD_NAME") == "" {
+		eventf = func(eventType, reason, msg string, args ...interface{}) {}
+		logs.Log.Printf("error messages will not show in the pod's events because the POD_NAME environment variable is empty")
+	} else {
+		podName := os.Getenv("POD_NAME")
+
+		eventClient, err := kubernetes.NewForConfig(restcfg)
+		if err != nil {
+			return eventf, fmt.Errorf("failed to create event client: %v", err)
+		}
+		broadcaster := record.NewBroadcaster()
+		broadcaster.StartRecordingToSink(&clientgocorev1.EventSinkImpl{Interface: eventClient.CoreV1().Events(installNS)})
+		eventRec := broadcaster.NewRecorder(scheme, corev1.EventSource{})
+		eventf = func(eventType, reason, msg string, args ...interface{}) {
+			eventRec.Eventf(&corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: installNS}}, eventType, reason, msg, args...)
+		}
+	}
+
+	return eventf, nil
+}
+
+// Like Printf but for sending events to the agent's Pod object.
+type Eventf func(eventType, reason, msg string, args ...interface{})
+
+func gatherAndOutputData(eventf Eventf, config CombinedConfig, preflightClient client.Client, dataGatherers map[string]datagatherer.DataGatherer) {
 	var readings []*api.DataReading
 
 	if config.InputPath != "" {
@@ -226,6 +277,7 @@ func gatherAndOutputData(config CombinedConfig, preflightClient client.Client, d
 			return postData(config, preflightClient, readings)
 		}
 		err := backoff.RetryNotify(post, backOff, func(err error, t time.Duration) {
+			eventf("Warning", "PushingErr", "retrying in %v after error: %s", t, err)
 			logs.Log.Printf("retrying in %v after error: %s", t, err)
 		})
 		if err != nil {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	clientgocorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -231,7 +232,7 @@ func newEventf(installNS string) (Eventf, error) {
 		broadcaster.StartRecordingToSink(&clientgocorev1.EventSinkImpl{Interface: eventClient.CoreV1().Events(installNS)})
 		eventRec := broadcaster.NewRecorder(scheme, corev1.EventSource{})
 		eventf = func(eventType, reason, msg string, args ...interface{}) {
-			eventRec.Eventf(&corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: installNS}}, eventType, reason, msg, args...)
+			eventRec.Eventf(&corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: installNS, UID: types.UID(os.Getenv("POD_UID"))}}, eventType, reason, msg, args...)
 		}
 	}
 


### PR DESCRIPTION
Ref: [VC-35568](https://venafi.atlassian.net/browse/VC-35568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ "AGENT: Show a warning in the Pod's events when the Venafi Connection isn't present in the cluster")

This feature aims at giving the user another way of knowing when the Agent isn't sending data to the VCP API. With this PR, the user will have two ways of noticing that the Agent isn't properly working:

- By looking at the logs (but hard since the logs are overwhelming (cf. [VC-33564](https://venafi.atlassian.net/browse/VC-33564 "AGENT: Important logs are drown in a sea of server missing resource for datagatherer")),
- By looking at the Kubernetes events on the Agent pod.

**POSSIBLE BREAKING CHANGE 1:** Previously, `--install-namespace` was only needed when using the VenafiConnection mode (i.e., using `--venafi-connection`). Starting with this PR, all modes will require knowing what the pod's namespace is. For context, ~the namespace is looked up in `/var/run/secrets/kubernetes.io/serviceaccount/namespace` if the pod has a service account mounted to it (always the case for the agent)~ it looks for the contents of `POD_NAMESPACE` defined in the deployment; otherwise, it uses the contents of `--install-namespace` (meant for running the agent out-of-cluster for testing purposes).

**Is this really a breaking change?** Very low chance of breakage since `POD_NAMESPACE` has been added to the Helm chart regardless of the auth mode.

<!--

**Is this really a breaking change?** Very low chance of breakage, there is likely no reason for this to break anyone. Regardless of the auth mode, the Agent requires a service account to be mounted to the pod, so the Agent will always be able to load the namespace from the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`. And even if the user has used `--set serviceAccount.create=false` (very unlikely!!), it should still work since the user must mount a service account for the Agent to function.

-->

**POSSIBLE BREAKING CHANGE 2:** Previously, the namespace would be loaded from the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`. Now, it is loaded from the env var `POD_NAMESPACE`. The Helm chart has been updated with this env var. 

**Is this really a breaking change?** Low chance of breakage since folks will upgrade using the updated Helm chart which will contain `POD_NAMESPACE`.


## Testing

There are no automated tests for this change.

I tested the "events" feature with the following:

I've used the tenant https://ven-tlspk.venafi.cloud/. To access the API key, use the user `system.admin@tlspk.qa.venafi.io` and the password is visible in the page [Production Accounts](https://venafi.atlassian.net/wiki/spaces/CT/pages/2115404149) (private to Venafi). Then go to the settings and find the API key.

```sh
export APIKEY=...
```

I've then deployed the agent to a Kind cluster:

```bash
kind create cluster
venctl iam service-account agent create --name "$USER temp" \
  --vcp-region US \
  --output json \
  --owning-team $(curl -sS https://api.venafi.cloud/v1/teams -H "tppl-api-key: $APIKEY" | jq '.teams[0].id') \
  --output-file /tmp/agent-credentials.json \
  --api-key $APIKEY
make oci-push-preflight oci_preflight_image_name=ttl.sh/mael/venafi-agent oci_preflight_image_tag=v0.0.0-dev oci_platforms=linux/arm64,linux/amd64
make helm-chart oci_preflight_image_tag=v0.0.0-dev helm_chart_version=0.0.0-dev oci_preflight_image_name=ttl.sh/mael/venafi-agent
helm push _bin/scratch/image/venafi-kubernetes-agent-0.0.0-dev.tgz oci://ttl.sh/mael/charts
helm upgrade -i -n venafi --create-namespace venafi-kubernetes-agent oci://ttl.sh/mael/charts/venafi-kubernetes-agent --version 0.0.0-dev \
  --set config.clusterName="$USER temp" --set config.clientId="$(jq -r .client_id /tmp/agent-credentials.json)"
kubectl create secret generic -n venafi agent-credentials --from-literal=privatekey.pem="$(jq -r .private_key /tmp/agent-credentials.json)" \
  --dry-run=client -o yaml | kubectl apply -f -
```

Now, cause an error by re-deploying with a broken client ID, for example:


```bash
helm upgrade -i -n venafi --create-namespace venafi-kubernetes-agent oci://ttl.sh/mael/charts/venafi-kubernetes-agent --version 0.0.0-dev \
  --set config.clusterName="$USER temp" --set config.clientId=bogus
```

You should see in the pod's events:

```console
$ k describe -n venafi pod -l app.kubernetes.io/name=venafi-kubernetes-agent
Events:
  Type     Reason      Age   From                     Message
  ----     ------      ----  ----                     -------
  Normal   Scheduled   65s   default-scheduler        Successfully assigned venafi/venafi-kubernetes-agent-585989f47-4kj5g to kind-control-plane
  Normal   Pulled      65s   kubelet                  Container image "ttl.sh/mael/venafi-agent:v0.0.0-dev" already present on machine
  Normal   Created     65s   kubelet                  Created container venafi-kubernetes-agent
  Normal   Started     65s   kubelet                  Started container venafi-kubernetes-agent
  Warning  PushingErr  59s   venafi-kubernetes-agent  retrying in 31.071441118s after error: post to server failed: failed to execute http request to Venafi Control Plane. Request https://api.venafi.cloud/v1/oauth/token/serviceaccount, status code: 400, body: [{"error":"invalid_grant","error_description":"Not found"}
]
  Warning  PushingErr  28s  venafi-kubernetes-agent  retrying in 1m4.430613764s after error: post to server failed: failed to execute http request to Venafi Control Plane. Request https://api.venafi.cloud/v1/oauth/token/serviceaccount, status code: 400, body: [{"error":"invalid_grant","error_description":"Not found"}
]
```

[VC-35568]: https://venafi.atlassian.net/browse/VC-35568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VC-33564]: https://venafi.atlassian.net/browse/VC-33564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ