### PR TITLE
VC-36353: Helm: appVersion was missing the v prefix

### DIFF
--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -29,6 +29,7 @@ deploy_namespace := venafi
 helm_chart_repo_base := oci://quay.io/jetstack/charts
 helm_chart_source_dir := deploy/charts/venafi-kubernetes-agent
 helm_chart_name := venafi-kubernetes-agent
+helm_chart_app_version := $(VERSION)
 helm_chart_version := $(VERSION:v%=%)
 helm_labels_template_name := preflight.labels
 helm_docs_use_helm_tool := 1


### PR DESCRIPTION
While testing the alpha in https://github.com/jetstack/jetstack-secure/issues/586, I found that the appVersion is missing the `v` prefix. Weirdly enough, the image in the templated deployment had the the `v` prefix...

This PR is fixing `appVersion`.

## Manual test

```console
$ make helm-chart
$ helm show chart _bin/scratch/image/venafi-kubernetes-agent-1.1.0-6-gd18bbc5def3d17-dirty.tgz | grep -i version                                       
appVersion: v1.1.0-6-gd18bbc5def3d17-dirty
version: 1.1.0-6-gd18bbc5def3d17-dirty
```