### PR TITLE
[VC-35738] Update the E2E test script to use the makefile-modules build targets

### DIFF
--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -45,3 +45,11 @@ $(helm_chart_source_dir)/templates/venafi-connection-crd.yaml: $(helm_chart_sour
 shared_generate_targets := $(filter-out generate-crds,$(shared_generate_targets))
 shared_generate_targets += generate-crds-venconn
 
+.PHONY: test-e2e-gke
+## Run a basic E2E test on a GKE cluster
+## Build and install venafi-kubernetes-agent for VenafiConnection based authentication.
+## Wait for it to log a message indicating successful data upload.
+## See `hack/e2e/test.sh` for the full test script.
+## @category Testing
+test-e2e-gke:
+	./hack/e2e/test.sh


### PR DESCRIPTION
```console
$ make help
...
Testing
    test-unit                     > Unit tests
    test-e2e-gke                  > Run a basic E2E test on a GKE cluster
                                    Build and install venafi-kubernetes-agent for VenafiConnection based authentication.
                                    Wait for it to log a message indicating successful data upload.
                                    See `hack/e2e/test.sh` for the full test script.
```

```bash
make test-e2e-gke
```

```console
...
2024/10/10 16:40:49 retrying in 33.032458396s after error: post to server failed: while loading the VenafiConnection venafi/venafi-components: connection is not ready yet (building connection failed): chain element 1 (VCPOAuth) error: Post "https://api.venafi.eu/v1/oauth2/v2.0/9a0cab61-2b00-11ee-ba09-0733b0fe5adc/token": dial tcp: lookup api.venafi.eu on 34.118.224.10:53: read udp 10.40.1.4:37910->34.118.224.10:53: read: connection refused
2024/10/10 16:41:22 Posting data to:
2024/10/10 16:41:23 Data sent successfully.
```