### PR TITLE
VC-36510: Key Pair and Venafi Connection modes now use gzip compression

### DIFF
--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -383,7 +383,7 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 				organization_id: foo
 				cluster_id: bar
 				`)),
-			withCmdLineFlags("--disable-compression", "--credentials-file", path))
+			withCmdLineFlags("--disable-compression", "--credentials-file", path, "--install-namespace", "venafi"))
 		require.EqualError(t, err, "1 error occurred:\n\t* --disable-compression can only be used with the Venafi Cloud Key Pair Service Account and Venafi Cloud VenafiConnection modes\n\n")
 	})
 
@@ -674,8 +674,9 @@ func Test_ValidateAndCombineConfig_VenafiCloudKeyPair(t *testing.T) {
 				  uploader_id: no
 				  upload_path: /v1/tlspk/upload/clusterdata
 			`)),
-			withCmdLineFlags("--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath),
+			withCmdLineFlags("--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath, "--install-namespace", "venafi"),
 		)
+		require.NoError(t, err)
 		testutil.TrustCA(t, cl, cert)
 		assert.Equal(t, VenafiCloudKeypair, got.AuthMode)
 		require.NoError(t, err)
@@ -712,8 +713,9 @@ func Test_ValidateAndCombineConfig_VenafiCloudKeyPair(t *testing.T) {
 				  uploader_id: no
 				  upload_path: /v1/tlspk/upload/clusterdata
 			`)),
-			withCmdLineFlags("--disable-compression", "--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath),
+			withCmdLineFlags("--disable-compression", "--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath, "--install-namespace", "venafi"),
 		)
+		require.NoError(t, err)
 		testutil.TrustCA(t, cl, cert)
 		assert.Equal(t, VenafiCloudKeypair, got.AuthMode)
 		require.NoError(t, err)

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -373,6 +374,19 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 		assert.IsType(t, &client.OAuthClient{}, cl)
 	})
 
+	t.Run("jetstack-secure-oauth-auth: can't use --disable-compression", func(t *testing.T) {
+		path := withFile(t, `{"user_id":"fpp2624799349@affectionate-hertz6.platform.jetstack.io","user_secret":"foo","client_id": "k3TrDbfLhCgnpAbOiiT2kIE1AbovKzjo","client_secret": "f39w_3KT9Vp0VhzcPzvh-uVbudzqCFmHER3Huj0dvHgJwVrjxsoOQPIw_1SDiCfa","auth_server_domain":"auth.jetstack.io"}`)
+		_, _, err := ValidateAndCombineConfig(discardLogs(),
+			withConfig(testutil.Undent(`
+				server: https://api.venafi.eu
+				period: 1h
+				organization_id: foo
+				cluster_id: bar
+				`)),
+			withCmdLineFlags("--disable-compression", "--credentials-file", path))
+		require.EqualError(t, err, "1 error occurred:\n\t* --disable-compression can only be used with the Venafi Cloud Key Pair Service Account and Venafi Cloud VenafiConnection modes\n\n")
+	})
+
 	t.Run("jetstack-secure-oauth-auth: --credential-file used but file is missing", func(t *testing.T) {
 		t.Setenv("POD_NAMESPACE", "venafi")
 		got, _, err := ValidateAndCombineConfig(discardLogs(),
@@ -632,6 +646,81 @@ func Test_ValidateAndCombineConfig_VenafiCloudKeyPair(t *testing.T) {
 		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: "test cluster name"})
 		require.NoError(t, err)
 	})
+
+	t.Run("the request body is compressed", func(t *testing.T) {
+		srv, cert, setVenafiCloudAssert := testutil.FakeVenafiCloud(t)
+		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
+			if gotReq.URL.Path == "/v1/oauth/token/serviceaccount" {
+				return
+			}
+			assert.Equal(t, "/v1/tlspk/upload/clusterdata/no", gotReq.URL.Path)
+
+			// Let's check that the body is compressed as expected.
+			assert.Equal(t, "gzip", gotReq.Header.Get("Content-Encoding"))
+			uncompressR, err := gzip.NewReader(gotReq.Body)
+			require.NoError(t, err, "body might not be compressed")
+			defer uncompressR.Close()
+			uncompressed, err := io.ReadAll(uncompressR)
+			require.NoError(t, err)
+			assert.Contains(t, string(uncompressed), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
+		})
+		privKeyPath := withFile(t, fakePrivKeyPEM)
+		got, cl, err := ValidateAndCombineConfig(discardLogs(),
+			withConfig(testutil.Undent(`
+				server: `+srv.URL+`
+				period: 1h
+				cluster_id: "test cluster name"
+				venafi-cloud:
+				  uploader_id: no
+				  upload_path: /v1/tlspk/upload/clusterdata
+			`)),
+			withCmdLineFlags("--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath),
+		)
+		testutil.TrustCA(t, cl, cert)
+		assert.Equal(t, VenafiCloudKeypair, got.AuthMode)
+		require.NoError(t, err)
+
+		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: "test cluster name"})
+		require.NoError(t, err)
+	})
+
+	t.Run("--disable-compression works", func(t *testing.T) {
+		srv, cert, setVenafiCloudAssert := testutil.FakeVenafiCloud(t)
+		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
+			// Only care about /v1/tlspk/upload/clusterdata/:uploader_id?name=
+			if gotReq.URL.Path == "/v1/oauth/token/serviceaccount" {
+				return
+			}
+
+			assert.Equal(t, "/v1/tlspk/upload/clusterdata/no", gotReq.URL.Path)
+
+			// Let's check that the body isn't compressed.
+			assert.Equal(t, "", gotReq.Header.Get("Content-Encoding"))
+			b := new(bytes.Buffer)
+			_, err := b.ReadFrom(gotReq.Body)
+			require.NoError(t, err)
+			assert.Contains(t, b.String(), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
+		})
+
+		privKeyPath := withFile(t, fakePrivKeyPEM)
+		got, cl, err := ValidateAndCombineConfig(discardLogs(),
+			withConfig(testutil.Undent(`
+				server: `+srv.URL+`
+				period: 1h
+				cluster_id: "test cluster name"
+				venafi-cloud:
+				  uploader_id: no
+				  upload_path: /v1/tlspk/upload/clusterdata
+			`)),
+			withCmdLineFlags("--disable-compression", "--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath),
+		)
+		testutil.TrustCA(t, cl, cert)
+		assert.Equal(t, VenafiCloudKeypair, got.AuthMode)
+		require.NoError(t, err)
+
+		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: "test cluster name"})
+		require.NoError(t, err)
+	})
 }
 
 // Slower test cases due to envtest. That's why they are separated from the
@@ -711,8 +800,12 @@ func Test_ValidateAndCombineConfig_VenafiConnection(t *testing.T) {
 		})
 
 		cfg, cl, err := ValidateAndCombineConfig(discardLogs(),
-			Config{Server: "http://this-url-should-be-ignored", Period: 1 * time.Hour, ClusterID: "test cluster name"},
-			AgentCmdFlags{VenConnName: "venafi-components", InstallNS: "venafi"})
+			withConfig(testutil.Undent(`
+				server: http://this-url-should-be-ignored
+				period: 1h
+				cluster_id: test cluster name
+			`)),
+			withCmdLineFlags("--venafi-connection", "venafi-components", "--install-namespace", "venafi"))
 		require.NoError(t, err)
 
 		testutil.VenConnStartWatching(t, cl)
@@ -721,6 +814,53 @@ func Test_ValidateAndCombineConfig_VenafiConnection(t *testing.T) {
 		// TODO(mael): the client should keep track of the cluster ID, we
 		// shouldn't need to pass it as an option to
 		// PostDataReadingsWithOptions.
+		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: cfg.ClusterID})
+		require.NoError(t, err)
+	})
+
+	t.Run("the request is compressed by default", func(t *testing.T) {
+		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
+			// Let's check that the body is compressed as expected.
+			assert.Equal(t, "gzip", gotReq.Header.Get("Content-Encoding"))
+			uncompressR, err := gzip.NewReader(gotReq.Body)
+			require.NoError(t, err, "body might not be compressed")
+			defer uncompressR.Close()
+			uncompressed, err := io.ReadAll(uncompressR)
+			require.NoError(t, err)
+			assert.Contains(t, string(uncompressed), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
+		})
+		cfg, cl, err := ValidateAndCombineConfig(discardLogs(),
+			withConfig(testutil.Undent(`
+				period: 1h
+				cluster_id: test cluster name
+			`)),
+			withCmdLineFlags("--venafi-connection", "venafi-components", "--install-namespace", "venafi"))
+		require.NoError(t, err)
+		testutil.VenConnStartWatching(t, cl)
+		testutil.TrustCA(t, cl, cert)
+		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: cfg.ClusterID})
+		require.NoError(t, err)
+	})
+
+	t.Run("--disable-compression works", func(t *testing.T) {
+		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
+			// Let's check that the body isn't compressed.
+			assert.Equal(t, "", gotReq.Header.Get("Content-Encoding"))
+			b := new(bytes.Buffer)
+			_, err := b.ReadFrom(gotReq.Body)
+			require.NoError(t, err)
+			assert.Contains(t, b.String(), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
+		})
+		cfg, cl, err := ValidateAndCombineConfig(discardLogs(),
+			withConfig(testutil.Undent(`
+				server: `+srv.URL+`
+				period: 1h
+				cluster_id: test cluster name
+			`)),
+			withCmdLineFlags("--disable-compression", "--venafi-connection", "venafi-components", "--install-namespace", "venafi"))
+		require.NoError(t, err)
+		testutil.VenConnStartWatching(t, cl)
+		testutil.TrustCA(t, cl, cert)
 		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: cfg.ClusterID})
 		require.NoError(t, err)
 	})

--- a/pkg/client/client_venafi_cloud.go
+++ b/pkg/client/client_venafi_cloud.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -50,6 +51,8 @@ type (
 		jwtSigningAlg jwt.SigningMethod
 		lock          sync.RWMutex
 
+		disableCompression bool
+
 		// Made public for testing purposes.
 		Client *http.Client
 	}
@@ -84,7 +87,7 @@ const (
 
 // NewVenafiCloudClient returns a new instance of the VenafiCloudClient type that will perform HTTP requests using a bearer token
 // to authenticate to the backend API.
-func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiSvcAccountCredentials, baseURL string, uploaderID string, uploadPath string) (*VenafiCloudClient, error) {
+func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiSvcAccountCredentials, baseURL string, uploaderID string, uploadPath string, disableCompression bool) (*VenafiCloudClient, error) {
 	if err := credentials.Validate(); err != nil {
 		return nil, fmt.Errorf("cannot create VenafiCloudClient: %w", err)
 	}
@@ -107,15 +110,16 @@ func NewVenafiCloudClient(agentMetadata *api.AgentMetadata, credentials *VenafiS
 	}
 
 	return &VenafiCloudClient{
-		agentMetadata: agentMetadata,
-		credentials:   credentials,
-		baseURL:       baseURL,
-		accessToken:   &venafiCloudAccessToken{},
-		Client:        &http.Client{Timeout: time.Minute},
-		uploaderID:    uploaderID,
-		uploadPath:    uploadPath,
-		privateKey:    privateKey,
-		jwtSigningAlg: jwtSigningAlg,
+		agentMetadata:      agentMetadata,
+		credentials:        credentials,
+		baseURL:            baseURL,
+		accessToken:        &venafiCloudAccessToken{},
+		Client:             &http.Client{Timeout: time.Minute},
+		uploaderID:         uploaderID,
+		uploadPath:         uploadPath,
+		privateKey:         privateKey,
+		jwtSigningAlg:      jwtSigningAlg,
+		disableCompression: disableCompression,
 	}, nil
 }
 
@@ -260,11 +264,39 @@ func (c *VenafiCloudClient) Post(path string, body io.Reader) (*http.Response, e
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fullURL(c.baseURL, path), body)
+	var encodedBody io.Reader
+	if c.disableCompression {
+		encodedBody = body
+	} else {
+		compressed := new(bytes.Buffer)
+		gz := gzip.NewWriter(compressed)
+		if _, err := io.Copy(gz, body); err != nil {
+			return nil, err
+		}
+		err := gz.Close()
+		if err != nil {
+			return nil, err
+		}
+		encodedBody = compressed
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fullURL(c.baseURL, path), encodedBody)
 	if err != nil {
 		return nil, err
 	}
 
+	// We have noticed that NGINX, which is Venafi Control Plane's API gateway,
+	// has a limit on the request body size we can send (client_max_body_size).
+	// On large clusters, the agent may exceed this limit, triggering the error
+	// "413 Request Entity Too Large". Although this limit has been raised to
+	// 1GB, NGINX still buffers the requests that the agent sends because
+	// proxy_request_buffering isn't set to off. To reduce the strain on NGINX'
+	// memory and disk, to avoid further 413s, and to avoid reaching the maximum
+	// request body size of customer's proxies, we have decided to enable GZIP
+	// compression. Ref: https://venafi.atlassian.net/browse/VC-36434.
+	if !c.disableCompression {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/client/client_venconn_test.go
+++ b/pkg/client/client_venconn_test.go
@@ -233,6 +233,7 @@ func run_TestVenConnClient_PostDataReadingsWithOptions(restcfg *rest.Config, kcl
 			// Let's make sure we didn't forget to add the arbitrary "/no"
 			// (uploader_id) path segment to /v1/tlspk/upload/clusterdata.
 			assert.Equal(t, "/v1/tlspk/upload/clusterdata/no", r.URL.Path)
+			assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
 		})
 
 		certPool := x509.NewCertPool()
@@ -246,6 +247,7 @@ func run_TestVenConnClient_PostDataReadingsWithOptions(restcfg *rest.Config, kcl
 			"venafi-components",    // Name of the VenafiConnection.
 			testNameToNamespace(t), // Namespace of the VenafiConnection.
 			certPool,
+			false, // disableCompression
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
**Summary:**

- This PR is a remediation for the 413s returned by our NGINX gateway due to the fact that the request limit was set too low (smth around 100MB). See [VC-36510](https://venafi.atlassian.net/browse/VC-36510) to know more.
- On 26 Sept, as a first attempt at remediating this, we bumped NGINX's [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) from 256 MB to 1024 MB, and [`client_body_buffer_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size) from 128 MB to 750 MB ([gitlab MR](https://gitlab.com/venafi/vaas/applications/tls-protect-for-k8s/cloud-services/-/merge_requests/1237/diffs), [message](https://venafi.slack.com/archives/C04RXLJ99AB/p1727338288590219?thread_ts=1727331258.837779&cid=C04RXLJ99AB)).
  - Before this fix, NGINX used to return a 413 as soon as the `Content-Length` was above 256 MB. When the request body goes above 750 MB, the body is written to a temporary file to disk rather than buffered in memory.
  - After this this, NGINX hasn't returned any 413s, even when stress-testing it.
- Side note: **buffering in NGINX is still happening**. Keeping buffering on puts stress in terms of memory and disk on NGINX, and I don’t think there is a reason in buffering these requests. The setting in question is `proxy_request_buffering` and is `on` by default.
- The Venafi Control Plane API **doesn't publicly state that GZIP compression is possible**; I have tested it and it works, but we shall maybe talk to Prod Engineering.
- Compression hasn't been added for Standalone (Jetstack Secure OAuth and Jetstack Secure API token modes). In this PR, I only added compression for the Key Pair and Venafi Connection modes.
- Compression aims to lower the load on our intermediate NGNIX (because it buffers requests) as well as lower the egress cost for customers. Sending over 100MBs over the wire looked somewhat bad, enabling compression will improve that.
- To ease the pain that might be caused by adding compression, we decided to add `--disable-compression` and let the Support team tell customers. I'm also in favor of adding `--disable-compression` for development purposes (e.g., when using mitmproxy).

**Testing**

- [x] **Test 1:** (manual) test that the compression works in Venafi Connection mode by using `./hack/e2e/test.sh`. (see results below)
- [x] **Test 2:** (manual) test that the compression works in Key Pair mode. (see results below)
- [x] **Test 3:** test that the headers are correctly set in Key Pair mode. → unit test written.
- [x] **Test 4:** test that the headers are correctly set in Venafi Connection mode. → unit test written.
- [x] **Test 5:** test that no compression takes place when `--disable-compression` is used in Key Pair mode → unit test written
- [x] **Test 6:** test that no compression takes place when `--disable-compression` is used in Venafi Connection mode. → unit test written
- [x] **Test 7:** (manual) test that the data is actually in the S3 bucket. @tfadeyi will check this.

**Rollout Plan:**

- If Olu or somebody in Cloud Services is taking over the feature and releasing v1.2.0, they will assess how confident they are about releasing. Although this feature is important, it isn't critical, so they might wait until Richard is back (29th Oct) or Mael is back (4th Nov).
- Release v1.2.0 for all customers,
- `venctl` will not immediately get v1.2.0 for the reason explained in the `#venctl` channel. You can contact @SgtCoDFish or @tfadeyi to know more about that.
- Let the Support Team (@hawksight) know that this change might affect customers, and that they can tell them to use `--disable-compression` if a problem occurs.

**Before:** request body weights 49 MB:

```
POST https://api.venafi.cloud/v1/tlspk/upload/clusterdata/no?description=S2luZCBjbHVzdGVyIG9uIE1hZWwmIzM5O3MgQW9ydXMgaG9tZSBtYWNoaW5l&name=kind-mael HTTP/2.0
accept: application/json
content-type: application/json
authorization: Bearer REDACTED
content-length: 49000269
accept-encoding: gzip
user-agent: Go-http-client/2.0

{"agent_metadata":{...

HTTP/2.0 200 
date: Tue, 15 Oct 2024 08:42:45 GMT
content-type: application/json
www-authenticate: Bearer realm="Echo"
vary: Accept-Encoding
server: envoy
content-length: 70

{"status":"ok","organization":"756db001-280e-11ee-84fb-991f3177e2d0"}
```

**After:** request body weights 5 MB:

```
POST https://api.venafi.cloud/v1/tlspk/upload/clusterdata/no?description=S2luZCBjbHVzdGVyIG9uIE1hZWwmIzM5O3MgQW9ydXMgaG9tZSBtYWNoaW5l&name=kind-mael HTTP/2.0
authorization: Bearer REDACTED
accept: application/json
content-type: application/json
content-length: 5125690
accept-encoding: gzip
user-agent: Go-http-client/2.0

\x8b������\xff̽ͮh\xb9\x8d...

HTTP/2.0 200 
date: Tue, 15 Oct 2024 08:42:45 GMT
content-type: application/json
www-authenticate: Bearer realm="Echo"
vary: Accept-Encoding
server: envoy
content-length: 70

{"status":"ok","organization":"756db001-280e-11ee-84fb-991f3177e2d0"}
```

^ note that the above request is missing the `Content-Encoding: gzip` header. I fixed this in 22def464afb6f5d80f5b8aa68ad0fe058c6d37dc.

(see the section below to know how to reproduce this)

## Manual Tests

### Test 1

For this test, I've used the tenant https://ven-tlspk.venafi.cloud/. To access the API key, use the user `system.admin@tlspk.qa.venafi.io` and the password is visible in the page [Production Accounts](https://venafi.atlassian.net/wiki/spaces/CT/pages/2115404149) (private to Venafi). Then go to the settings and find the API key, and set it in the env var `APIKEY`.

The tenant https://ven-tlspk.venafi.cloud/ doesn't have the right tier to pull images, so I use an API key from the tenant https://glow-in-the-dark.venafi.cloud/, that's why I set the env var `APIKEY_GLOW_IN_THE_DARK`. Ask Atanas to get access to the tenant https://glow-in-the-dark.venafi.cloud/.

```sh
export APIKEY=...
export APIKEY_GLOW_IN_THE_DARK=...
```

Then:

```sh
export \
 OCI_BASE=ttl.sh/maelvls \
 VEN_API_KEY=$APIKEY \
 VEN_API_KEY_PULL=$APIKEY_GLOW_IN_THE_DARK \
 VEN_API_HOST=api.venafi.cloud \
 VEN_VCP_REGION=us \
 VEN_ZONE='tlspk-bench\Default' \
 CLOUDSDK_CORE_PROJECT=jetstack-mael-valais \
 CLOUDSDK_COMPUTE_ZONE=europe-west1-b \
 CLUSTER_NAME=test-secretless
```

Finally, run the smoke test Venafi Connection mode:

```sh
./hack/e2e/test.sh
```

Result:

```
2024/10/18 19:18:35 Posting data to:
2024/10/18 19:18:36 Data sent successfully.
```

### Test 2

For this test, I've decided to use mitmproxy to see exactly what is being sent on the wire.

First, copy the following script to a file called `bigjsonbody.go` (written in Go because bash is super slow):

```go
///usr/bin/true; exec /usr/bin/env go run "$0" "$@"

package main

import (
	"encoding/json"
	"flag"
	"fmt"
	"time"

	"github.com/google/uuid"
)

var (
	count = flag.Int("count", 5000, "Number of items to generate")
)

type Metadata struct {
	Name              string            `json:"name"`
	Namespace         string            `json:"namespace"`
	UID               string            `json:"uid"`
	CreationTimestamp string            `json:"creationTimestamp"`
	Labels            map[string]string `json:"labels"`
}

type Resource struct {
	Kind       string   `json:"kind"`
	APIVersion string   `json:"apiVersion"`
	Metadata   Metadata `json:"metadata"`
}

type Item struct {
	Resource Resource `json:"resource"`
}

type Data struct {
	Items []Item `json:"items"`
}

type Output struct {
	ClusterID    string    `json:"cluster_id"`
	DataGatherer string    `json:"data-gatherer"`
	Timestamp    time.Time `json:"timestamp"`
	Data         Data      `json:"data"`
}

func generateItem() Item {
	randomUID := uuid.New().String()
	return Item{
		Resource: Resource{
			Kind:       "Pod",
			APIVersion: "v1",
			Metadata: Metadata{
				Name:              "test-" + randomUID,
				Namespace:         "test",
				UID:               randomUID,
				CreationTimestamp: "2024-09-20T18:03:51Z",
				Labels: map[string]string{
					"k8s-app": "test",
				},
			},
		},
	}
}

func main() {
	flag.Parse()
	items := make([]Item, *count)

	for i := 0; i < *count; i++ {
		items[i] = generateItem()
	}

	output := Output{
		ClusterID:    "mael temp",
		DataGatherer: "k8s/pods",
		Timestamp:    time.Date(2024, time.September, 30, 16, 47, 32, 0, time.FixedZone("CET", 2*3600)),
		Data:         Data{Items: items},
	}

	outputJSON, err := json.MarshalIndent(output, "", "  ")
	if err != nil {
		fmt.Println("Error:", err)
		return
	}

	fmt.Println(string(outputJSON))
}
```
Then:

```
chmod +x bigjsonbody.go
```

Finally:

```
$ ./bigjsonbody.go --count=200000 >input-data.json
du -h input-data.json
87M    input-data.json
```

For this tests, I've used the tenant https://ven-tlspk.venafi.cloud/. To access the API key, use the user `system.admin@tlspk.qa.venafi.io` and the password is visible in the page [Production Accounts](https://venafi.atlassian.net/wiki/spaces/CT/pages/2115404149) (private to Venafi). Then go to the settings and find the API key, and set it as an env var:

```sh
export APIKEY=...
```

Create the service account and key pair:

```bash
venctl iam service-account agent create --name "$USER temp" \
  --vcp-region US \
  --output json \
  --owning-team $(curl -sS https://api.venafi.cloud/v1/teams -H "tppl-api-key: $APIKEY" | jq '.teams[0].id') \
  --output-file /tmp/agent-credentials.json \
  --api-key $APIKEY
```

Now, make sure to have `127.0.0.1 me` in your `/etc/hosts`.

Then, run mitmproxy with:

```sh
curl -L https://raw.githubusercontent.com/maelvls/kubectl-incluster/main/watch-stream.py >/tmp/watch-stream.py
mitmproxy --mode regular@9090 --ssl-insecure -s /tmp/watch-stream.py --set client_certs=$(kubectl incluster --print-client-cert >/tmp/me.pem && echo /tmp/me.pem)
```

Run this:

```bash
cat <<EOF >minimal-config.yaml
cluster_id: "kind-mael"
cluster_description: "Kind cluster on Mael's machine"
server: "https://api.venafi.cloud/"
venafi-cloud:
  uploader_id: "no"
  upload_path: "/v1/tlspk/upload/clusterdata"
data-gatherers: []
period: 3m
EOF
```

Finally, run the Agent with:

```sh
go install github.com/maelvls/kubectl-incluster@latest
export HTTPS_PROXY=http://localhost:9090 KUBECONFIG=/tmp/kube && KUBECONFIG= HTTPS_PROXY= kubectl incluster --replace-ca-cert ~/.mitmproxy/mitmproxy-ca-cert.pem --sa=venafi/venafi-kubernetes-agent | sed 's|127.0.0.1|me|' >/tmp/kube

go run . agent -c minimal-config.yaml \
  --client-id $(jq -r .client_id /tmp/agent-credentials.json) \
  --private-key-path <(jq -r .private_key /tmp/agent-credentials.json) \
  --install-namespace=venafi \
  --input-path=input-data.json \
  --one-shot
```

Result:

```
2024/10/18 19:18:35 Posting data to: https://api.venafi.cloud/
2024/10/18 19:18:36 Data sent successfully.
```

[VC-36510]: https://venafi.atlassian.net/browse/VC-36510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ