### PR TITLE
[VC-35738] Bubble up the errors from sub-commands and handle errors centrally instead of using log.Fatal at multiple sites

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jetstack/preflight/pkg/agent"
-	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/jetstack/preflight/pkg/permissions"
 )
 
@@ -16,7 +15,7 @@ var agentCmd = &cobra.Command{
 	Short: "start the preflight agent",
 	Long: `The agent will periodically gather data for the configured data
 	gatherers and send it to a remote backend for evaluation`,
-	Run: agent.Run,
+	RunE: agent.Run,
 }
 
 var agentInfoCmd = &cobra.Command{
@@ -34,24 +33,25 @@ var agentRBACCmd = &cobra.Command{
 	Use:   "rbac",
 	Short: "print the agent's minimal RBAC manifest",
 	Long:  `Print RBAC string by reading GVRs`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 
 		b, err := os.ReadFile(agent.Flags.ConfigFilePath)
 		if err != nil {
-			logs.Log.Fatalf("Failed to read config file: %s", err)
+			return fmt.Errorf("Failed to read config file: %s", err)
 		}
 		cfg, err := agent.ParseConfig(b)
 		if err != nil {
-			logs.Log.Fatalf("Failed to parse config file: %s", err)
+			return fmt.Errorf("Failed to parse config file: %s", err)
 		}
 
 		err = agent.ValidateDataGatherers(cfg.DataGatherers)
 		if err != nil {
-			logs.Log.Fatalf("Failed to validate data gatherers: %s", err)
+			return fmt.Errorf("Failed to validate data gatherers: %s", err)
 		}
 
 		out := permissions.GenerateFullManifest(cfg.DataGatherers)
 		fmt.Print(out)
+		return nil
 	},
 }
 

--- a/cmd/echo.go
+++ b/cmd/echo.go
@@ -11,7 +11,7 @@ var echoCmd = &cobra.Command{
 	Short: "starts an echo server to test the agent",
 	Long: `The agent sends data to a server. This echo server
 can be used to act as the server part and echo the data received by the agent.`,
-	Run: echo.Echo,
+	RunE: echo.Echo,
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,14 @@ Preflight checks are bundled into Packages`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logs.Initialize()
 	},
+	// SilenceErrors and SilenceUsage prevents this command or any sub-command
+	// from printing arbitrary text to stderr.
+	// Why? To ensure that each line of output can be parsed as a single message
+	// for consumption by logging agents such as fluentd.
+	// Usage information is still available on stdout with the `-h` and `--help`
+	// flags.
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+
+	"github.com/jetstack/preflight/pkg/logs"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -31,13 +33,16 @@ func init() {
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
+// If the root command or sub-command returns an error, the error message will
+// will be logged and the process will exit with status 1.
 func Execute() {
 	logs.AddFlags(rootCmd.PersistentFlags())
-
+	var exitCode int
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		exitCode = 1
+		klog.ErrorS(err, "Exiting due to error", "exit-code", exitCode)
 	}
+	klog.FlushAndExit(klog.ExitFlushTimeout, exitCode)
 }
 
 func setFlagsFromEnv(prefix string, fs *pflag.FlagSet) {

--- a/pkg/echo/echo.go
+++ b/pkg/echo/echo.go
@@ -9,20 +9,16 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jetstack/preflight/api"
-	"github.com/jetstack/preflight/pkg/logs"
 )
 
 var EchoListen string
 
 var Compact bool
 
-func Echo(cmd *cobra.Command, args []string) {
+func Echo(cmd *cobra.Command, args []string) error {
 	http.HandleFunc("/", echoHandler)
 	fmt.Println("Listening to requests at ", EchoListen)
-	err := http.ListenAndServe(EchoListen, nil)
-	if err != nil {
-		logs.Log.Fatal(err)
-	}
+	return http.ListenAndServe(EchoListen, nil)
 }
 
 func echoHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -147,12 +147,7 @@ func (w LogToSlogWriter) Write(p []byte) (n int, err error) {
 
 	message := string(p)
 	if strings.Contains(message, "error") ||
-		strings.Contains(message, "failed") ||
-		strings.Contains(message, "fatal") ||
-		strings.Contains(message, "Failed") ||
-		strings.Contains(message, "While evaluating configuration") ||
-		strings.Contains(message, "data-path override present") ||
-		strings.Contains(message, "Cannot marshal readings") {
+		strings.Contains(message, "failed") {
 		w.Slog.With("source", w.Source).Error(message)
 	} else {
 		w.Slog.With("source", w.Source).Info(message)

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -375,52 +375,22 @@ func Test_replaceWithStaticTimestamps(t *testing.T) {
 }
 
 func TestLogToSlogWriter(t *testing.T) {
-	// This test makes sure that all the agent's Log.Fatalf calls are correctly
-	// translated to slog.Error calls.
+	// This test makes sure that all the agent's remaining Log calls are correctly
+	// translated to slog.Error calls where appropriate.
 	//
 	// This list was generated using:
-	//  grep -r "Log\.Fatalf" ./cmd ./pkg
+	//  git grep -i "log\.\(print\|fatal\)" pkg/ cmd/  | fgrep -e error -e failed
 	given := strings.TrimPrefix(`
-Failed to load config file for agent from
-Failed to read config file
-Failed to parse config file
-While evaluating configuration
-failed to run pprof profiler
-failed to run the health check server
-failed to start a controller-runtime component
-failed to wait for controller-runtime component to stop
-running data gatherer %s of type %s as Local, data-path override present
-failed to instantiate %q data gatherer
-failed to read local data file
-failed to unmarshal local data file
-failed to output to local file
-Exiting due to fatal error uploading
-halting datagathering in strict mode due to error
-Cannot marshal readings
-Failed to read config file
-Failed to parse config file
-Failed to validate data gatherers
+failed to complete initial sync of %q data gatherer %q: %v
+error messages will not show in the pod's events because the POD_NAME environment variable is empty
+retrying in %v after error: %s
+datagatherer informer for %q has failed and is backing off due to error: %s
 this is a happy log that should show as INFO`, "\n")
 	expect := strings.TrimPrefix(`
-level=ERROR msg="Failed to load config file for agent from" source=agent
-level=ERROR msg="Failed to read config file" source=agent
-level=ERROR msg="Failed to parse config file" source=agent
-level=ERROR msg="While evaluating configuration" source=agent
-level=ERROR msg="failed to run pprof profiler" source=agent
-level=ERROR msg="failed to run the health check server" source=agent
-level=ERROR msg="failed to start a controller-runtime component" source=agent
-level=ERROR msg="failed to wait for controller-runtime component to stop" source=agent
-level=ERROR msg="running data gatherer %!s(MISSING) of type %!s(MISSING) as Local, data-path override present" source=agent
-level=ERROR msg="failed to instantiate %!q(MISSING) data gatherer" source=agent
-level=ERROR msg="failed to read local data file" source=agent
-level=ERROR msg="failed to unmarshal local data file" source=agent
-level=ERROR msg="failed to output to local file" source=agent
-level=ERROR msg="Exiting due to fatal error uploading" source=agent
-level=ERROR msg="halting datagathering in strict mode due to error" source=agent
-level=ERROR msg="Cannot marshal readings" source=agent
-level=ERROR msg="Failed to read config file" source=agent
-level=ERROR msg="Failed to parse config file" source=agent
-level=ERROR msg="Failed to validate data gatherers" source=agent
+level=ERROR msg="failed to complete initial sync of %!q(MISSING) data gatherer %!q(MISSING): %!v(MISSING)" source=agent
+level=ERROR msg="error messages will not show in the pod's events because the POD_NAME environment variable is empty" source=agent
+level=ERROR msg="retrying in %!v(MISSING) after error: %!s(MISSING)" source=agent
+level=ERROR msg="datagatherer informer for %!q(MISSING) has failed and is backing off due to error: %!s(MISSING)" source=agent
 level=INFO msg="this is a happy log that should show as INFO" source=agent
 `, "\n")
 


### PR DESCRIPTION
This is a small part of a larger effort to allow the agent to use structured logging.
This will make it easier for platform administrators to parse the logs and to distinguish errors from info messages.
It also is a small part of an effort to use contextual logging instead of the legacy `log` module.
This will make it easier to test the log output of our code in unit tests.

The existing code uses `log.Fatal` at the site of various errors to both print the error and to exit the process with code 1.
Instead the errors should be returned and bubbled back to the root command, which makes it easier to handle the errors in a consistent fashion and makes it easier to test the code that had previously caused the process to exit.

```console
$ git grep -i '\.fatal' | grep -v 't\.Fatal'

```

Example output:

```console
$ POD_NAMESPACE=venafi ./preflight agent --one-shot --output-path /dev/null --api-token should-not-be-required  --agent-config-file examples/cert-manager-agent.yaml -v 1
I1105 13:28:59.806101   86250 logs.go:158] "Preflight agent version: development ()" source="agent"
I1105 13:28:59.806320   86250 logs.go:158] "Using the Jetstack Secure API Token auth mode since --api-token was specified." source="agent"
I1105 13:28:59.806344   86250 logs.go:158] "Using deprecated Endpoint configuration. User Server instead." source="agent"
I1105 13:28:59.806362   86250 run.go:117] "Healthz endpoints enabled" logger="APIServer" addr=":8081" path="/healthz"
I1105 13:28:59.806389   86250 run.go:121] "Readyz endpoints enabled" logger="APIServer" addr=":8081" path="/readyz"
I1105 13:28:59.806464   86250 run.go:447] "Starting" logger="APIServer.ListenAndServe" addr=":8081"
E1105 13:28:59.807120   86250 logs.go:156] "error messages will not show in the pod's events because the POD_NAME environment variable is empty" source="agent"
I1105 13:28:59.807717   86250 logs.go:158] "starting \"k8s/secrets.v1\" datagatherer" source="agent"
I1105 13:28:59.807854   86250 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I1105 13:28:59.807888   86250 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I1105 13:29:00.008575   86250 logs.go:158] "successfully gathered 18 items from \"k8s/secrets.v1\" datagatherer" source="agent"
I1105 13:29:00.009067   86250 logs.go:158] "Data saved to local file: /dev/null" source="agent"
I1105 13:29:00.009147   86250 run.go:461] "Shutting down" logger="APIServer.ListenAndServe" addr=":8081"
I1105 13:29:00.009205   86250 run.go:476] "Shutdown complete" logger="APIServer.ListenAndServe" addr=":8081"

$ echo $?
0
```

```console
$ ./preflight agent --foo
E1105 13:30:18.198379   86557 root.go:51] "Exiting due to error" err="unknown flag: --foo" exit-code=1

$ echo $?
1
```

```console
$ ./preflight agent
I1105 13:30:52.936075   86581 logs.go:153] "Preflight agent version: development ()" source="agent"
E1105 13:30:52.936271   86581 root.go:51] "Exiting due to error" err=<
        While evaluating configuration: no auth mode specified. You can use one of four auth modes:
         - Use (--venafi-cloud with --credentials-file) or (--client-id with --private-key-path) to use the Venafi Cloud Key Pair Service Account mode.
         - Use --venafi-connection for the Venafi Cloud VenafiConnection mode.
         - Use --credentials-file alone if you want to use the Jetstack Secure OAuth mode.
         - Use --api-token if you want to use the Jetstack Secure API Token mode.
 > exit-code=1

$ echo $?
1
```

```console
$ ./preflight agent --one-shot --output-path /foo/bar --api-token should-not-be-required  --agent-config-file examples/cert-manager-agent.yaml
I1105 13:31:38.686969   86604 logs.go:153] "Preflight agent version: development ()" source="agent"
I1105 13:31:38.687764   86604 logs.go:153] "Using the Jetstack Secure API Token auth mode since --api-token was specified." source="agent"
I1105 13:31:38.687789   86604 logs.go:153] "Using deprecated Endpoint configuration. User Server instead." source="agent"
E1105 13:31:38.687815   86604 root.go:51] "Exiting due to error" err=<
        While evaluating configuration: 1 error occurred:
                * could not guess which namespace the agent is running in: POD_NAMESPACE env var not set, meaning that you are probably not running in cluster. Please use --install-namespace or POD_NAMESPACE to specify the namespace in which the agent is running.

 > exit-code=1

$ echo $?
1
```