### PR TITLE
[VC-35738] Move the pprof endpoints to the main HTTP server rather than starting a second server

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -281,7 +281,7 @@ func InitAgentCmdFlags(c *cobra.Command, cfg *AgentCmdFlags) {
 		"enable-pprof",
 		"",
 		false,
-		"Enables the pprof profiling server on the agent (port: 6060).",
+		"Enables the pprof profiling endpoints on the agent server (port: 8081).",
 	)
 	c.PersistentFlags().BoolVarP(
 		&cfg.Prometheus,


### PR DESCRIPTION
The pprof server was being started on a second HTTP server running in an unmanaged Go routine.
It used log.Fatal on exit to bring down the process in the event of an error in that server.
Moving the pprof endpoints to the main HTTP server simplifies the code because it avoids having to manage a second server.
It will make it easier to enable TLS on these endpoints in future, if that is desired, because only a single TLS certificate will be required.
It makes life easier for platform admins who will have one less TCP port to worry about.
It removes one more instance of `log.Fatal`, which are scattered all over the run command and moves us closer to removing the use of the legacy `log` module and handling all sub-command errors in a consistent way.

These changes have been extracted from a larger prototype PR: https://github.com/jetstack/jetstack-secure/pull/593 for the sake of easy review.

The `--enable-pprof` feature was originally added by @tfadeyi  in https://github.com/jetstack/jetstack-secure/pull/286 to aid the investigation of the high memory usage of the agent.

xref:
 * https://github.com/jetstack/jetstack-secure/pull/599
 * https://github.com/jetstack/jetstack-secure/pull/596
 * https://github.com/jetstack/jetstack-secure/pull/593
 * https://github.com/jetstack/jetstack-secure/pull/286

<img width="480" alt="image" src="https://github.com/user-attachments/assets/76c9b200-6e9b-4eb0-a0bc-48a6cf0cca8c">

```console
$ POD_NAMESPACE=venafi ./preflight agent --output-path /dev/null --api-token should-not-be-required  --agent-config-file examples/cert-manager-agent.yaml --enable-pprof --period 1h
2024/10/30 10:02:43 Preflight agent version: development ()
2024/10/30 10:02:43 Using the Jetstack Secure API Token auth mode since --api-token was specified.
2024/10/30 10:02:43 Using deprecated Endpoint configuration. User Server instead.
2024/10/30 10:02:43 pprof profiling was enabled.
...
```

```console
$ ./preflight agent --help | grep -i pprof
      --enable-pprof                                      Enables the pprof profiling endpoints on the agent server (port: 8081).
```