### PR TITLE
[VC-35738] Allow DataGatherer.Run to return without stopping the other errgroup Go Routines

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -183,11 +183,14 @@ func Run(cmd *cobra.Command, args []string) error {
 
 		// start the data gatherers and wait for the cache sync
 		group.Go(func() error {
+			// Most implementations of `DataGatherer.Run` return immediately.
+			// Only the Dynamic DataGatherer starts an informer which runs and
+			// blocks until the supplied channel is closed.
+			// For this reason, we must allow these errgroup Go routines to exit
+			// without cancelling the other Go routines in the group.
 			if err := newDg.Run(gctx.Done()); err != nil {
 				return fmt.Errorf("failed to start %q data gatherer %q: %v", kind, dgConfig.Name, err)
 			}
-			// The agent must stop if any of the data gatherers stops
-			cancel()
 			return nil
 		})
 


### PR DESCRIPTION
In https://github.com/jetstack/jetstack-secure/pull/601#discussion_r1831253638 I introduced a bug which caused the API server and VenafiConnection helper to exit as a result of the early return of some `DataGatherer.Run` implementations.

Tested using `hack/e2e/test.sh`.

Before this change, the venctl  installation part of the script failed,
because the healthz server gets quickly shutdown as a result of the Discovery DataGatherer.Run function returning and cancelling the errgroup.
This causes the Liveness check to fail, and the Helm install never succeeds.

After this change, the test script works again:

```console
$ ./hack/e2e/test.sh
...
{
  "ts": 1730909040560.407,
  "caller": "logs/logs.go:153",
  "msg": "successfully gathered 10 items from \"k8s/namespaces\" datagatherer",
  "source": "agent",
  "v": 0
}
{
  "ts": 1730909040560.5063,
  "caller": "logs/logs.go:153",
  "msg": "successfully gathered 0 items from \"k8s/googlecasclusterissuers\" datagatherer",
  "source": "agent",
  "v": 0
}
{
  "ts": 1730909040560.5884,
  "caller": "logs/logs.go:153",
  "msg": "successfully gathered 0 items from \"k8s/gateways\" datagatherer",
  "source": "agent",
  "v": 0
}
{
  "ts": 1730909040560.6826,
  "caller": "logs/logs.go:153",
  "msg": "Posting data to: ",
  "source": "agent",
  "v": 0
}
{"ts":1730909041447.9111,"caller":"logs/logs.go:153","msg":"Data sent successfully.","source":"agent","v":0}
```