### PR TITLE
Allow specification of client_id by env var

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -201,10 +201,10 @@ func InitAgentCmdFlags(c *cobra.Command, cfg *AgentCmdFlags) {
 		&cfg.ClientID,
 		"client-id",
 		"",
-		"",
+		os.Getenv("CLIENT_ID"),
 		fmt.Sprintf("Turns on the %s mode. If you use this flag you don't need to use --venafi-cloud "+
 			"as it will assume you are authenticating with Venafi Cloud. Using this removes the need to use a "+
-			"credentials file.", VenafiCloudKeypair),
+			"credentials file. Defaults to the value of the env var CLIENT_ID", VenafiCloudKeypair),
 	)
 	c.PersistentFlags().StringVarP(
 		&cfg.PrivateKeyPath,

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -312,6 +312,21 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 		assert.IsType(t, &client.VenafiCloudClient{}, cl)
 	})
 
+	t.Run("venafi-cloud-keypair-auth: authenticated if CLIENT_ID set", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "venafi")
+		t.Setenv("CLIENT_ID", "test-client-id")
+		path := withFile(t, fakePrivKeyPEM)
+		_, cl, err := ValidateAndCombineConfig(discardLogs(),
+			withConfig(testutil.Undent(`
+				cluster_id: foo
+				venafi-cloud:
+				  upload_path: /foo/bar
+			`)),
+			withCmdLineFlags("--venafi-cloud", "--period", "1m", "--private-key-path", path))
+		require.NoError(t, err)
+		assert.IsType(t, &client.VenafiCloudClient{}, cl)
+	})
+
 	t.Run("venafi-cloud-keypair-auth: valid 1: --client-id and --private-key-path", func(t *testing.T) {
 		t.Setenv("POD_NAMESPACE", "venafi")
 		path := withFile(t, fakePrivKeyPEM)


### PR DESCRIPTION
Specifying client_id by env var allows us to pre-populate a namespace with all the relevant authentication details.

Currently, we have to populate a secret with a private key, and then create a deployment given the client id. Specifying via an env var would allow us to create/rotate deployments and credentials independently of each other.

e.g.

```
env:
 - name: CLIENT_ID
   valueFrom:
     configMapKeyRef:
       name: venafi-agent-svc-account
       key: client_id
```