### PR TITLE
[VC-35738] Use klog and logr logger instead of log in the agent package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -45,8 +46,9 @@ func init() {
 // will be logged and the process will exit with status 1.
 func Execute() {
 	logs.AddFlags(rootCmd.PersistentFlags())
+	ctx := klog.NewContext(context.Background(), klog.Background())
 	var exitCode int
-	if err := rootCmd.Execute(); err != nil {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		exitCode = 1
 		klog.ErrorS(err, "Exiting due to error", "exit-code", exitCode)
 	}

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -6,15 +6,16 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2/ktesting"
 
 	"github.com/jetstack/preflight/pkg/client"
 	"github.com/jetstack/preflight/pkg/testutil"
@@ -86,7 +87,7 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 
 	t.Run("--period flag takes precedence over period field in config, shows warning", func(t *testing.T) {
 		t.Setenv("POD_NAMESPACE", "venafi")
-		log, gotLogs := recordLogs()
+		log, gotLogs := recordLogs(t)
 		got, _, err := ValidateAndCombineConfig(log,
 			withConfig(testutil.Undent(`
 				server: https://api.venafi.eu
@@ -97,8 +98,8 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 			withCmdLineFlags("--period", "99m", "--credentials-file", fakeCredsPath))
 		require.NoError(t, err)
 		assert.Equal(t, testutil.Undent(`
-			Using the Jetstack Secure OAuth auth mode since --credentials-file was specified without --venafi-cloud.
-			Both the 'period' field and --period are set. Using the value provided with --period.
+			INFO Using the Jetstack Secure OAuth auth mode since --credentials-file was specified without --venafi-cloud.
+			INFO Both the 'period' field and --period are set. Using the value provided with --period.
 		`), gotLogs.String())
 		assert.Equal(t, 99*time.Minute, got.Period)
 	})
@@ -573,7 +574,7 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 	t.Run("venafi-cloud-workload-identity-auth: warning about server, venafi-cloud.uploader_id, and venafi-cloud.upload_path being skipped", func(t *testing.T) {
 		t.Setenv("POD_NAMESPACE", "venafi")
 		t.Setenv("KUBECONFIG", withFile(t, fakeKubeconfig))
-		log, gotLogs := recordLogs()
+		log, gotLogs := recordLogs(t)
 		got, gotCl, err := ValidateAndCombineConfig(log,
 			withConfig(testutil.Undent(`
 				server: https://api.venafi.eu
@@ -587,11 +588,11 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.Equal(t, testutil.Undent(`
-			Using the Venafi Cloud VenafiConnection auth mode since --venafi-connection was specified.
-			ignoring the server field specified in the config file. In Venafi Cloud VenafiConnection mode, this field is not needed.
-			ignoring the venafi-cloud.upload_path field in the config file. In Venafi Cloud VenafiConnection mode, this field is not needed.
-			ignoring the venafi-cloud.uploader_id field in the config file. This field is not needed in Venafi Cloud VenafiConnection mode.
-			Using period from config 1h0m0s
+			INFO Using the Venafi Cloud VenafiConnection auth mode since --venafi-connection was specified.
+			INFO ignoring the server field specified in the config file. In Venafi Cloud VenafiConnection mode, this field is not needed.
+			INFO ignoring the venafi-cloud.upload_path field in the config file. In Venafi Cloud VenafiConnection mode, this field is not needed.
+			INFO ignoring the venafi-cloud.uploader_id field in the config file. This field is not needed in Venafi Cloud VenafiConnection mode.
+			INFO Using period from config period="1h0m0s"
 		`), gotLogs.String())
 		assert.Equal(t, VenafiCloudVenafiConnection, got.AuthMode)
 		assert.IsType(t, &client.VenConnClient{}, gotCl)
@@ -994,13 +995,15 @@ func withFile(t testing.TB, content string) string {
 	return f.Name()
 }
 
-func recordLogs() (*log.Logger, *bytes.Buffer) {
-	b := bytes.Buffer{}
-	return log.New(&b, "", 0), &b
+func recordLogs(t *testing.T) (logr.Logger, ktesting.Buffer) {
+	log := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+	testingLogger, ok := log.GetSink().(ktesting.Underlier)
+	require.True(t, ok)
+	return log, testingLogger.GetBuffer()
 }
 
-func discardLogs() *log.Logger {
-	return log.New(io.Discard, "", 0)
+func discardLogs() logr.Logger {
+	return logr.Discard()
 }
 
 // Shortcut for ParseConfig.


### PR DESCRIPTION
The aim of this PR is to remove the stdlib `log` package and the use of the legacy `github.com/jetstack/jetstack-secure/logs.Log` variable, from the `agent` package. 

I'll create followup PRs to remove `logs.Log` elsewhere in the code, and ultimately remove that global variable.

```console
$ go test ./cmd/... -v
=== RUN   TestAgentRunOneShot
    agent_test.go:41: Running child process
    agent_test.go:59: STDOUT
        I1107 16:10:35.015613  305780 run.go:57] "Starting" logger="Run" version="development" commit=""
        I1107 16:10:35.017213  305780 config.go:395] "Using the Jetstack Secure API Token auth mode since --api-token was specified." logger="Run"
        I1107 16:10:35.017789  305780 run.go:115] "Healthz endpoints enabled" logger="Run.APIServer" addr=":8081" path="/healthz"
        I1107 16:10:35.017860  305780 run.go:119] "Readyz endpoints enabled" logger="Run.APIServer" addr=":8081" path="/readyz"
        I1107 16:10:35.017965  305780 run.go:457] "Starting" logger="Run.APIServer.ListenAndServe" addr=":8081"
        I1107 16:10:35.019399  305780 run.go:288] "Reading data from local file" logger="Run.gatherAndOutputData" inputPath="testdata/agent/one-shot/success/input.json"
        I1107 16:10:35.019913  305780 run.go:314] "Data saved to local file" logger="Run.gatherAndOutputData" outputPath="/dev/null"
        I1107 16:10:35.020000  305780 run.go:471] "Shutting down" logger="Run.APIServer.ListenAndServe" addr=":8081"
        I1107 16:10:35.020049  305780 run.go:486] "Shutdown complete" logger="Run.APIServer.ListenAndServe" addr=":8081"

    agent_test.go:60: STDERR

--- PASS: TestAgentRunOneShot (0.03s)
PASS
ok      github.com/jetstack/preflight/cmd       0.059s
```

```console
$ ./hack/e2e/test.sh
...
{
  "ts": 1730995936301.0586,
  "caller": "agent/run.go:348",
  "msg": "Successfully gathered",
  "v": 0,
  "logger": "Run.gatherAndOutputData.gatherData",
  "count": 0,
  "name": "k8s/gateways"
}
{
  "ts": 1730995936301.145,
  "caller": "agent/run.go:348",
  "msg": "Successfully gathered",
  "v": 0,
  "logger": "Run.gatherAndOutputData.gatherData",
  "count": 0,
  "name": "k8s/virtualservices"
}
{
  "ts": 1730995936301.2642,
  "caller": "agent/run.go:381",
  "msg": "Posting data",
  "v": 0,
  "logger": "Run.gatherAndOutputData.postData",
  "baseURL": ""
}
{"ts":1730995937172.0322,"caller":"agent/run.go:392","msg":"Data sent successfully","v":0,"logger":"Run.gatherAndOutputData.postData"}
```