### PR TITLE
[VC-35738] Remove os.Exit from the logs module

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,8 +20,8 @@ var rootCmd = &cobra.Command{
 configuration checks using Open Policy Agent (OPA).
 
 Preflight checks are bundled into Packages`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		logs.Initialize()
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return logs.Initialize()
 	},
 	// SilenceErrors and SilenceUsage prevents this command or any sub-command
 	// from printing arbitrary text to stderr.

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -108,13 +107,12 @@ func AddFlags(fs *pflag.FlagSet) {
 
 // Initialize uses k8s.io/component-base/logs, to configure the following global
 // loggers: log, slog, and klog. All are configured to write in the same format.
-func Initialize() {
+func Initialize() error {
 	// This configures the global logger in klog *and* slog, if compiled with Go
 	// >= 1.21.
 	logs.InitLogs()
 	if err := logsapi.ValidateAndApply(configuration, features); err != nil {
-		fmt.Fprintf(os.Stderr, "Error in logging configuration: %v\n", err)
-		os.Exit(2)
+		return fmt.Errorf("Error in logging configuration: %s", err)
 	}
 
 	// Thanks to logs.InitLogs, slog.Default now uses klog as its backend. Thus,
@@ -133,6 +131,7 @@ func Initialize() {
 	// to the global log logger. It can be removed when this is fixed upstream
 	// in vcert:  https://github.com/Venafi/vcert/pull/512
 	vcertLog.SetPrefix("")
+	return nil
 }
 
 type LogToSlogWriter struct {


### PR DESCRIPTION
Instead of calling os.exit directly after parsing and finding an error in the logging flags, the error is now returned and handled the same way as errors that come from the `Run` function....they are logged using structured logging and the logs are flushed before the process exits.

I've adjusted the logs tests accordingly and modified them so that the log flag parsing and error handling in the tests matches the behaviour of the actual command.

Before:
```console
$ ./preflight agent --logging-format=foo
Error in logging configuration: format: Invalid value: "foo": Unsupported log format

$ echo $?
2
```

After:
```console
$ ./preflight agent --logging-format=foo
E1107 13:41:31.063915  281828 root.go:51] "Exiting due to error" err="Error in logging configuration: format: Invalid value: \"foo\": Unsupported log format" exit-code=1

$ echo $?
1
```