### PR TITLE
[VC-35738] Replace logs.Log with logr.Logger in the remaining code

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -34,12 +34,6 @@ import (
 //    upon which this code was based.
 
 var (
-	// This is the Agent's logger. For now, it is still a *log.Logger, but we
-	// mean to migrate everything to slog with the klog backend. We avoid using
-	// log.Default because log.Default is already used by the VCert library, and
-	// we need to keep the agent's logger from the VCert's logger to be able to
-	// remove the `vCert: ` prefix from the VCert logs.
-	Log *log.Logger
 
 	// All but the essential logging flags will be hidden to avoid overwhelming
 	// the user. The hidden flags can still be used. For example if a user does
@@ -119,9 +113,6 @@ func Initialize() error {
 	// the client-go library, which relies on klog.Info, has the same logger as
 	// the agent, which still uses log.Printf.
 	slog := slog.Default()
-
-	Log = &log.Logger{}
-	Log.SetOutput(LogToSlogWriter{Slog: slog, Source: "agent"})
 
 	// Let's make sure the VCert library, which is the only library we import to
 	// be using the global log.Default, also uses the common slog logger.


### PR DESCRIPTION
The aim of this PR is to remove the remaining references to the `logs.Log` variable and replace them with context derived `logr.Logger` calls.

I haven't given much thought to the log levels because I think we're going to be removing most of the messages about missing CRDs and permissions errors in another feature.

```console
$ go test ./pkg/datagatherer/k8s/... -v -run TestNoneCache -count 1
=== RUN   TestNoneCache
    cache.go:53: E1107 17:57:50.964580] Cache update failure err="not a cacheResource type: *k8s.notCachable missing metadata/uid field" operation="add"
    cache.go:66: E1107 17:57:50.964680] Cache update failure err="not a cacheResource type: *k8s.notCachable missing metadata/uid field" operation="update"
    cache.go:80: E1107 17:57:50.964689] Cache update failure err="not a cacheResource type: *k8s.notCachable missing metadata/uid field" operation="delete"
--- PASS: TestNoneCache (0.00s)
PASS
ok      github.com/jetstack/preflight/pkg/datagatherer/k8s      0.025s
```



```bash
 ./hack/e2e/test.sh
```

```json
{
  "ts": 1731002359611.0227,
  "caller": "cache/reflector.go:561",
  "msg": "k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list firefly.venafi.com/v1, Resource=issuers: issuers.firefly.venafi.com is forbidden: User \"system:serviceaccount:venafi:venafi-kubernetes-agent\" cannot list resource \"issuers\" in API group \"firefly.venafi.com\" at the cluster scope",
  "v": 0
}
{
  "ts": 1731002359611.0823,
  "caller": "k8s/dynamic.go:278",
  "msg": "datagatherer informer has failed and is backing off",
  "v": 0,
  "groupVersionResource": "firefly.venafi.com/v1, Resource=issuers",
  "reason": "failed to list firefly.venafi.com/v1, Resource=issuers: issuers.firefly.venafi.com is forbidden: User \"system:serviceaccount:venafi:venafi-kubernetes-agent\" cannot list resource \"issuers\" in API group \"firefly.venafi.com\" at the cluster scope"
}
```

```json
{
  "ts": 1731002360493.6667,
  "caller": "k8s/dynamic.go:276",
  "msg": "server missing resource for datagatherer",
  "v": 0,
  "groupVersionResource": "networking.istio.io/v1alpha3, Resource=gateways"
}
{
  "ts": 1731002360614.0635,
  "caller": "cache/reflector.go:561",
  "msg": "k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list networking.istio.io/v1alpha3, Resource=virtualservices: the server could not find the requested resource",
  "v": 0
}

```

<img width="960" alt="image" src="https://github.com/user-attachments/assets/c8b7de40-82e7-497f-8c14-a2784b45e281">
