### PR TITLE
[VC-33564] Fix unknown resource errors when using the cert-manager config example

### DIFF
--- a/examples/cert-manager-agent.yaml
+++ b/examples/cert-manager-agent.yaml
@@ -14,23 +14,23 @@ data-gatherers:
       version: v1
       resource: secrets
 - kind: "k8s-dynamic"
-  name: "k8s/certificates.v1alpha2.cert-manager.io"
+  name: "k8s/certificates.v1.cert-manager.io"
   config:
     resource-type:
       group: cert-manager.io
-      version: v1alpha2
+      version: v1
       resource: certificates
 - kind: "k8s-dynamic"
-  name: "k8s/ingresses.v1beta1.networking.k8s.io"
+  name: "k8s/ingresses.v1.networking.k8s.io"
   config:
     resource-type:
       group: networking.k8s.io
-      version: v1beta1
+      version: v1
       resource: ingresses
 - kind: "k8s-dynamic"
-  name: "k8s/certificaterequests.v1alpha2.cert-manager.io"
+  name: "k8s/certificaterequests.v1.cert-manager.io"
   config:
     resource-type:
       group: cert-manager.io
-      version: v1alpha2
+      version: v1
       resource: certificaterequests


### PR DESCRIPTION
I often try the `examples/cert-manager.yaml` for testing but the resource versions are wrong so it logs tons of errors.

Before:
```console
$ go run ./ agent --install-namespace venafi --one-shot --output-path out.master.js --api-token should-not-be-required  --agent-config-file examples/cert-manager-agent.yaml
2024/11/08 09:37:30 Preflight agent version: development ()
2024/11/08 09:37:30 Using the Jetstack Secure API Token auth mode since --api-token was specified.
2024/11/08 09:37:30 Using deprecated Endpoint configuration. User Server instead.
2024/11/08 09:37:30 error messages will not show in the pod's events because the POD_NAME environment variable is empty
2024/11/08 09:37:30 starting "k8s/secrets.v1" datagatherer
2024/11/08 09:37:30 starting "k8s/certificates.v1alpha2.cert-manager.io" datagatherer
2024/11/08 09:37:30 starting "k8s/ingresses.v1beta1.networking.k8s.io" datagatherer
2024/11/08 09:37:30 starting "k8s/certificaterequests.v1alpha2.cert-manager.io" datagatherer
W1108 09:37:30.692073  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list cert-manager.io/v1alpha2, Resource=certificates: the server could not find the requested resource
W1108 09:37:30.692165  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list cert-manager.io/v1alpha2, Resource=certificaterequests: the server could not find the requested resource
2024/11/08 09:37:30 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificates"
2024/11/08 09:37:30 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificaterequests"
W1108 09:37:30.692073  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list networking.k8s.io/v1beta1, Resource=ingresses: the server could not find the requested resource
2024/11/08 09:37:30 server missing resource for datagatherer of "networking.k8s.io/v1beta1, Resource=ingresses"
W1108 09:37:31.806200  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list cert-manager.io/v1alpha2, Resource=certificaterequests: the server could not find the requested resource
2024/11/08 09:37:31 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificaterequests"
W1108 09:37:31.913963  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list networking.k8s.io/v1beta1, Resource=ingresses: the server could not find the requested resource
2024/11/08 09:37:31 server missing resource for datagatherer of "networking.k8s.io/v1beta1, Resource=ingresses"
W1108 09:37:32.001687  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list cert-manager.io/v1alpha2, Resource=certificates: the server could not find the requested resource
2024/11/08 09:37:32 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificates"
W1108 09:37:33.745888  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list cert-manager.io/v1alpha2, Resource=certificates: the server could not find the requested resource
2024/11/08 09:37:33 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificates"
W1108 09:37:33.786705  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list cert-manager.io/v1alpha2, Resource=certificaterequests: the server could not find the requested resource
2024/11/08 09:37:33 server missing resource for datagatherer of "cert-manager.io/v1alpha2, Resource=certificaterequests"
W1108 09:37:34.855009  343819 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list networking.k8s.io/v1beta1, Resource=ingresses: the server could not find the requested resource
2024/11/08 09:37:34 server missing resource for datagatherer of "networking.k8s.io/v1beta1, Resource=ingresses"
2024/11/08 09:37:35 failed to complete initial sync of "k8s-dynamic" data gatherer "k8s/certificates.v1alpha2.cert-manager.io": timed out waiting for Kubernetes caches to sync
2024/11/08 09:37:35 failed to complete initial sync of "k8s-dynamic" data gatherer "k8s/ingresses.v1beta1.networking.k8s.io": timed out waiting for Kubernetes caches to sync
2024/11/08 09:37:35 failed to complete initial sync of "k8s-dynamic" data gatherer "k8s/certificaterequests.v1alpha2.cert-manager.io": timed out waiting for Kubernetes caches to sync
2024/11/08 09:37:35 successfully gathered 16 items from "k8s/secrets.v1" datagatherer
2024/11/08 09:37:35 successfully gathered 0 items from "k8s/certificates.v1alpha2.cert-manager.io" datagatherer
2024/11/08 09:37:35 successfully gathered 0 items from "k8s/ingresses.v1beta1.networking.k8s.io" datagatherer
2024/11/08 09:37:35 successfully gathered 0 items from "k8s/certificaterequests.v1alpha2.cert-manager.io" datagatherer
2024/11/08 09:37:35 Data saved to local file: out.master.js
```

After:

```console
$ go run ./ agent --install-namespace venafi --one-shot --output-path out.branch.js --api-token should-not-be-required  --agent-config-file examples/cert-manager-agent.yaml
2024/11/08 09:38:44 Preflight agent version: development ()
2024/11/08 09:38:44 Using the Jetstack Secure API Token auth mode since --api-token was specified.
2024/11/08 09:38:44 Using deprecated Endpoint configuration. User Server instead.
2024/11/08 09:38:44 error messages will not show in the pod's events because the POD_NAME environment variable is empty
2024/11/08 09:38:44 starting "k8s/secrets.v1" datagatherer
2024/11/08 09:38:44 starting "k8s/certificates.v1.cert-manager.io" datagatherer
2024/11/08 09:38:44 starting "k8s/ingresses.v1.networking.k8s.io" datagatherer
2024/11/08 09:38:44 starting "k8s/certificaterequests.v1.cert-manager.io" datagatherer
2024/11/08 09:38:46 successfully gathered 0 items from "k8s/ingresses.v1.networking.k8s.io" datagatherer
2024/11/08 09:38:46 successfully gathered 1 items from "k8s/certificaterequests.v1.cert-manager.io" datagatherer
2024/11/08 09:38:46 successfully gathered 16 items from "k8s/secrets.v1" datagatherer
2024/11/08 09:38:46 successfully gathered 1 items from "k8s/certificates.v1.cert-manager.io" datagatherer
2024/11/08 09:38:46 Data saved to local file: out.branch.js
```
