### PR TITLE
VC-36950: It is now possible to exclude labels and annotations

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -423,6 +423,26 @@ Control Plane.
 > ```yaml
 > helm.sh/release.v1
 > ```
+#### **config.excludeAnnotationKeysRegex** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.  
+  
+If you would like to exclude annotations keys that contain the word  
+`secret`, use the regular expression `.*secret.*`. The leading and ending .*  
+are important if you want to filter out keys that contain `secret` anywhere in the key string.  
+  
+Note that the annotation `kubectl.kubernetes.io/last-applied-configuration` is already excluded by default, you don't need to exclude it explicitly.  
+  
+Example: excludeAnnotationKeysRegex: [".*secret.*"]
+#### **config.excludeLabelKeysRegex** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
 #### **config.configmap.name** ~ `unknown`
 > Default value:
 > ```yaml

--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -431,11 +431,9 @@ Control Plane.
 
 You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.  
   
-If you would like to exclude annotations keys that contain the word `word`, use the regular expression `.*word.*`. The leading and ending .* are important if you want to filter out keys that contain `word` anywhere in the key string.  
+Dots is the only character that needs to be escaped in the regex. Use either double quotes with escaped single quotes or unquoted strings for the regex to avoid YAML parsing issues with `\.`.  
   
-Note that the annotation `kubectl.kubernetes.io/last-applied-configuration` is already excluded by default, you don't need to exclude it explicitly.  
-  
-Example: excludeAnnotationKeysRegex: ["kapp\.k14s\.io\/original.*"]
+Example: excludeAnnotationKeysRegex: ['^kapp\.k14s\.io/original.*']
 #### **config.excludeLabelKeysRegex** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -431,13 +431,11 @@ Control Plane.
 
 You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.  
   
-If you would like to exclude annotations keys that contain the word  
-`secret`, use the regular expression `.*secret.*`. The leading and ending .*  
-are important if you want to filter out keys that contain `secret` anywhere in the key string.  
+If you would like to exclude annotations keys that contain the word `word`, use the regular expression `.*word.*`. The leading and ending .* are important if you want to filter out keys that contain `word` anywhere in the key string.  
   
 Note that the annotation `kubectl.kubernetes.io/last-applied-configuration` is already excluded by default, you don't need to exclude it explicitly.  
   
-Example: excludeAnnotationKeysRegex: [".*secret.*"]
+Example: excludeAnnotationKeysRegex: ["kapp\.k14s\.io\/original.*"]
 #### **config.excludeLabelKeysRegex** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -14,9 +14,9 @@ data:
     server: {{ .Values.config.server | quote }}
     period: {{ .Values.config.period | quote }}
     exclude-annotation-keys-regex:
-      {{ .Values.config.excludeAnnotationKeysRegex | nindent 6 }}
+      {{ .Values.config.excludeAnnotationKeysRegex | toYaml | nindent 6 }}
     exclude-label-keys-regex:
-      {{ .Values.config.excludeLabelKeysRegex | nindent 6 }}
+      {{ .Values.config.excludeLabelKeysRegex | toYaml | nindent 6 }}
     venafi-cloud:
       uploader_id: "no"
       upload_path: "/v1/tlspk/upload/clusterdata"

--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -13,6 +13,10 @@ data:
     cluster_description: {{ .Values.config.clusterDescription | quote }}
     server: {{ .Values.config.server | quote }}
     period: {{ .Values.config.period | quote }}
+    exclude-annotation-keys-regex:
+      {{ .Values.config.excludeAnnotationKeysRegex | nindent 6 }}
+    exclude-label-keys-regex:
+      {{ .Values.config.excludeLabelKeysRegex | nindent 6 }}
     venafi-cloud:
       uploader_id: "no"
       upload_path: "/v1/tlspk/upload/clusterdata"

--- a/deploy/charts/venafi-kubernetes-agent/values.schema.json
+++ b/deploy/charts/venafi-kubernetes-agent/values.schema.json
@@ -165,6 +165,12 @@
         "configmap": {
           "$ref": "#/$defs/helm-values.config.configmap"
         },
+        "excludeAnnotationKeysRegex": {
+          "$ref": "#/$defs/helm-values.config.excludeAnnotationKeysRegex"
+        },
+        "excludeLabelKeysRegex": {
+          "$ref": "#/$defs/helm-values.config.excludeLabelKeysRegex"
+        },
         "ignoredSecretTypes": {
           "$ref": "#/$defs/helm-values.config.ignoredSecretTypes"
         },
@@ -206,6 +212,17 @@
     },
     "helm-values.config.configmap.key": {},
     "helm-values.config.configmap.name": {},
+    "helm-values.config.excludeAnnotationKeysRegex": {
+      "default": [],
+      "description": "You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.\n\nIf you would like to exclude annotations keys that contain the word\n`secret`, use the regular expression `.*secret.*`. The leading and ending .*\nare important if you want to filter out keys that contain `secret` anywhere in the key string.\n\nNote that the annotation `kubectl.kubernetes.io/last-applied-configuration` is already excluded by default, you don't need to exclude it explicitly.\n\nExample: excludeAnnotationKeysRegex: [\".*secret.*\"]",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.config.excludeLabelKeysRegex": {
+      "default": [],
+      "items": {},
+      "type": "array"
+    },
     "helm-values.config.ignoredSecretTypes": {
       "items": {
         "$ref": "#/$defs/helm-values.config.ignoredSecretTypes[0]"

--- a/deploy/charts/venafi-kubernetes-agent/values.schema.json
+++ b/deploy/charts/venafi-kubernetes-agent/values.schema.json
@@ -214,7 +214,7 @@
     "helm-values.config.configmap.name": {},
     "helm-values.config.excludeAnnotationKeysRegex": {
       "default": [],
-      "description": "You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.\n\nIf you would like to exclude annotations keys that contain the word `word`, use the regular expression `.*word.*`. The leading and ending .* are important if you want to filter out keys that contain `word` anywhere in the key string.\n\nNote that the annotation `kubectl.kubernetes.io/last-applied-configuration` is already excluded by default, you don't need to exclude it explicitly.\n\nExample: excludeAnnotationKeysRegex: [\"kapp\\.k14s\\.io\\/original.*\"]",
+      "description": "You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.\n\nDots is the only character that needs to be escaped in the regex. Use either double quotes with escaped single quotes or unquoted strings for the regex to avoid YAML parsing issues with `\\.`.\n\nExample: excludeAnnotationKeysRegex: ['^kapp\\.k14s\\.io/original.*']",
       "items": {},
       "type": "array"
     },

--- a/deploy/charts/venafi-kubernetes-agent/values.schema.json
+++ b/deploy/charts/venafi-kubernetes-agent/values.schema.json
@@ -214,7 +214,7 @@
     "helm-values.config.configmap.name": {},
     "helm-values.config.excludeAnnotationKeysRegex": {
       "default": [],
-      "description": "You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.\n\nIf you would like to exclude annotations keys that contain the word\n`secret`, use the regular expression `.*secret.*`. The leading and ending .*\nare important if you want to filter out keys that contain `secret` anywhere in the key string.\n\nNote that the annotation `kubectl.kubernetes.io/last-applied-configuration` is already excluded by default, you don't need to exclude it explicitly.\n\nExample: excludeAnnotationKeysRegex: [\".*secret.*\"]",
+      "description": "You can configure Venafi Kubernetes Agent to exclude some annotations or labels from being pushed to the Venafi Control Plane. All Kubernetes objects are affected. The objects are still pushed, but the specified annotations and labels are removed before being sent to the Venafi Control Plane.\n\nIf you would like to exclude annotations keys that contain the word `word`, use the regular expression `.*word.*`. The leading and ending .* are important if you want to filter out keys that contain `word` anywhere in the key string.\n\nNote that the annotation `kubectl.kubernetes.io/last-applied-configuration` is already excluded by default, you don't need to exclude it explicitly.\n\nExample: excludeAnnotationKeysRegex: [\"kapp\\.k14s\\.io\\/original.*\"]",
       "items": {},
       "type": "array"
     },

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -238,6 +238,23 @@ config:
   - bootstrap.kubernetes.io/token
   - helm.sh/release.v1
 
+  # You can configure Venafi Kubernetes Agent to exclude some annotations or
+  # labels from being pushed to the Venafi Control Plane. All Kubernetes objects
+  # are affected. The objects are still pushed, but the specified annotations
+  # and labels are removed before being sent to the Venafi Control Plane.
+  #
+  # If you would like to exclude annotations keys that contain the word
+  # `secret`, use the regular expression `.*secret.*`. The leading and ending .*
+  # are important if you want to filter out keys that contain `secret` anywhere
+  # in the key string.
+  #
+  # Note that the annotation `kubectl.kubernetes.io/last-applied-configuration`
+  # is already excluded by default, you don't need to exclude it explicitly.
+  #
+  # Example: excludeAnnotationKeysRegex: [".*secret.*"]
+  excludeAnnotationKeysRegex: []
+  excludeLabelKeysRegex: []
+
   # Specify ConfigMap details to load config from an existing resource.
   # This should be blank by default unless you have you own config.
   configmap:

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -114,7 +114,7 @@ podSecurityContext: {}
 securityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
 
@@ -230,28 +230,24 @@ config:
   # * https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
   # * https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/#list-of-supported-fields
   ignoredSecretTypes:
-  - kubernetes.io/service-account-token
-  - kubernetes.io/dockercfg
-  - kubernetes.io/dockerconfigjson
-  - kubernetes.io/basic-auth
-  - kubernetes.io/ssh-auth
-  - bootstrap.kubernetes.io/token
-  - helm.sh/release.v1
+    - kubernetes.io/service-account-token
+    - kubernetes.io/dockercfg
+    - kubernetes.io/dockerconfigjson
+    - kubernetes.io/basic-auth
+    - kubernetes.io/ssh-auth
+    - bootstrap.kubernetes.io/token
+    - helm.sh/release.v1
 
   # You can configure Venafi Kubernetes Agent to exclude some annotations or
   # labels from being pushed to the Venafi Control Plane. All Kubernetes objects
   # are affected. The objects are still pushed, but the specified annotations
   # and labels are removed before being sent to the Venafi Control Plane.
   #
-  # If you would like to exclude annotations keys that contain the word `word`,
-  # use the regular expression `.*word.*`. The leading and ending .* are
-  # important if you want to filter out keys that contain `word` anywhere in the
-  # key string.
+  # Dots is the only character that needs to be escaped in the regex. Use either
+  # double quotes with escaped single quotes or unquoted strings for the regex
+  # to avoid YAML parsing issues with `\.`.
   #
-  # Note that the annotation `kubectl.kubernetes.io/last-applied-configuration`
-  # is already excluded by default, you don't need to exclude it explicitly.
-  #
-  # Example: excludeAnnotationKeysRegex: ["kapp\.k14s\.io\/original.*"]
+  # Example: excludeAnnotationKeysRegex: ['^kapp\.k14s\.io/original.*']
   excludeAnnotationKeysRegex: []
   excludeLabelKeysRegex: []
 

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -243,15 +243,15 @@ config:
   # are affected. The objects are still pushed, but the specified annotations
   # and labels are removed before being sent to the Venafi Control Plane.
   #
-  # If you would like to exclude annotations keys that contain the word
-  # `secret`, use the regular expression `.*secret.*`. The leading and ending .*
-  # are important if you want to filter out keys that contain `secret` anywhere
-  # in the key string.
+  # If you would like to exclude annotations keys that contain the word `word`,
+  # use the regular expression `.*word.*`. The leading and ending .* are
+  # important if you want to filter out keys that contain `word` anywhere in the
+  # key string.
   #
   # Note that the annotation `kubectl.kubernetes.io/last-applied-configuration`
   # is already excluded by default, you don't need to exclude it explicitly.
   #
-  # Example: excludeAnnotationKeysRegex: [".*secret.*"]
+  # Example: excludeAnnotationKeysRegex: ["kapp\.k14s\.io\/original.*"]
   excludeAnnotationKeysRegex: []
   excludeLabelKeysRegex: []
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/client"
 	"github.com/jetstack/preflight/pkg/datagatherer"
+	"github.com/jetstack/preflight/pkg/datagatherer/k8s"
 	"github.com/jetstack/preflight/pkg/kubeconfig"
 	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/jetstack/preflight/pkg/version"
@@ -174,6 +175,12 @@ func Run(cmd *cobra.Command, args []string) (returnErr error) {
 		newDg, err := dgConfig.Config.NewDataGatherer(gctx)
 		if err != nil {
 			return fmt.Errorf("failed to instantiate %q data gatherer  %q: %v", kind, dgConfig.Name, err)
+		}
+
+		dynDg, isDynamicGatherer := newDg.(*k8s.DataGathererDynamic)
+		if isDynamicGatherer {
+			dynDg.ExcludeAnnotKeys = config.ExcludeAnnotationKeysRegex
+			dynDg.ExcludeLabelKeys = config.ExcludeLabelKeysRegex
 		}
 
 		log.V(logs.Debug).Info("Starting DataGatherer", "name", dgConfig.Name)

--- a/pkg/datagatherer/k8s/dynamic_test.go
+++ b/pkg/datagatherer/k8s/dynamic_test.go
@@ -618,16 +618,24 @@ func TestDynamicGatherer_Fetch(t *testing.T) {
 			//      username: bXl1c2VybmFtZQ==
 			//
 			//  [1]: https://github.com/carvel-dev/kapp/issues/90#issuecomment-602074356
-			excludeAnnotsKeys: []string{`kapp\.k14s\.io\/original.*`},
+			//
+			// The regular expression could be:
+			excludeAnnotsKeys: []string{`^kapp\.k14s\.io/original.*`},
 
-			// We haven't found convincing examples of labels that may contain
-			// sensitive information in the wild, so let's go with a dumb
-			// example.
-			excludeLabelKeys: []string{`.*sensitive.*`},
+			// A somewhat realistic example of labels that would need to be
+			// excluded would be when a company declares ownership using
+			// sensitive identifiers (e.g., employee IDs), and the company
+			// doesn't want these IDs to be exposed. Let's imagine these
+			// employee IDs look like this:
+			//
+			//  company.com/employee-id: 12345
+			//
+			// The regular expression would then be:
+			excludeLabelKeys: []string{`^company\.com/employee-id$`},
 
 			addObjects: []runtime.Object{getObjectAnnot("v1", "Secret", "s0", "n1",
 				map[string]interface{}{"kapp.k14s.io/original": "foo", "kapp.k14s.io/original-diff": "bar", "normal": "true"},
-				map[string]interface{}{"is-sensitive-label": "true", "prod": "true"},
+				map[string]interface{}{`company.com/employee-id`: "12345", "prod": "true"},
 			)},
 			expected: []*api.GatheredResource{{Resource: getObjectAnnot("v1", "Secret", "s0", "n1",
 				map[string]interface{}{"normal": "true"},


### PR DESCRIPTION
Some annotations and labels contain sensitive information. A well-known example is the `kubectl.kubernetes.io/last-applied-configuration` annotation. We already exclude this annotations from Secret resources, but we have found that customers use other sensitive annotations and labels that they would like to not be sent to the Venafi Control Plane API.


A realistic example lies in the Kapp project. The Kapp project uses four annotations that all start with `kapp.k14s.io/original*` as seen in [1]. These annotations are similar to `kubectl.kubernetes.io/last-applied-configuration` in that they may contain sensitive information. The annotations would look like this:

```yaml
annotations:
  kapp.k14s.io/original: |
    {"apiVersion":"v1","kind":"Secret","spec":{"data": {"password": "cGFzc3dvcmQ=","username": "bXl1c2VybmFtZQ=="}}}
  kapp.k14s.io/original-diff: |
    - type: test
      path: /data
      value:
      password: cygpcGVyUzNjcmV0UEBhc3N3b3JkIQ==
      username: bXl1c2VybmFtZQ==
```

[1]: https://github.com/carvel-dev/kapp/issues/90#issuecomment-602074356

In this case, customers will be suggested to use the following exclusion setting in `values.yaml` to exclude both `kapp.k14s.io/original` and `kapp.k14s.io/original-diff`:

```yaml
config:
  excludeAnnotationKeysRegex:
    - ^kapp\.k14s\.io/original
```

For labels, it looks like this:

```yaml
config:
  excludeLabelKeysRegex:
    - \.company\.com/
```

The documentation for this feature is being worked on in https://gitlab.com/venafi/vaas/ua/clouddocs/-/merge_requests/1220.

**Ref:** [VC-36950](https://venafi.atlassian.net/browse/VC-36950 "Step 2: Add the regex logic and expose the config fields excludeAnnotationKeysRegex and excludeLabelKeysRegex")

## Why regex, why not fixed string search with wildcards?

We have chosen to go with regexes instead of fixed-string search or wildcards. We know that using regexes will be confusing, but we don't expect this feature to be used so often, and since we don't know exactly the type of filtering that customers will want, we have decided to use the most versatile one : regexes.

## Manual Testing

Although I've added a couple of unit tests, I haven't had time to add an automated end-to-end test. In particular, my PR is **lacking a smoke test to check that the Helm chart value `excludeAnnotationKeysRegex` does what it claims it does**.

Here is the two manual tests that make me confident that this feature works as expected.

### Test 1: Using `--output-path` + fake Jetstack Secure API token

I used an empty Kind cluster for this test.

First, run this:

```bash
cat <<EOF >minimal-config.yaml
period: 5m
cluster_id: "kind-mael"
server: "https://api.venafi.cloud/"
organization_id: foo
venafi-cloud:
  upload_path: "/v1/tlspk/upload/clusterdata"
exclude-annotation-keys-regex:
  - ".*password.*"
  - ".*apikey.*"
exclude-label-keys-regex:
  - ".*password.*"
  - ".*apikey.*"
data-gatherers:
  - kind: "k8s-dynamic"
    name: "k8s/namespaces"
    config:
      resource-type:
        resource: namespaces
        version: v1
  - kind: "k8s-dynamic"
    name: "k8s/secrets"
    config:
      resource-type:
        version: v1
        resource: secrets
EOF
```

Then:

```sh
openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=mydomain.com/O=myorganization"
kubectl create secret tls my-tls-secret --cert=tls.crt --key=tls.key
kubectl annotate secret my-tls-secret some-secret-apikey=1234
kubectl label secret my-tls-secret some-secret-password=1234

kubectl create ns my-ns
kubectl annotate ns my-ns some-secret-apikey=1234
kubectl label ns my-ns some-secret-password=1234
```

Finally, run the agent in one-shot mode. You should see no output when running this:

```console
$ go run . agent -c minimal-config.yaml \
  --api-token should-not-be-required \
  --install-namespace=venafi \
  --output-path /dev/stdout \
  --one-shot | grep -B5 1234
2024/11/08 16:46:56 Preflight agent version: development ()
2024/11/08 16:46:56 Using the Jetstack Secure API Token auth mode since --api-token was specified.
2024/11/08 16:46:56 error messages will not show in the pod's events because the POD_NAME environment variable is empty
2024/11/08 16:46:56 starting "k8s/namespaces" datagatherer
2024/11/08 16:46:56 starting "k8s/secrets" datagatherer
2024/11/08 16:46:56 successfully gathered 7 items from "k8s/namespaces" datagatherer
2024/11/08 16:46:56 successfully gathered 5 items from "k8s/secrets" datagatherer
2024/11/08 16:46:56 Data saved to local file: /dev/stdout
```

Before this PR, the output would look like this:

```console
$ go run . agent -c minimal-config.yaml \
  --api-token should-not-be-required \
  --install-namespace=venafi \
  --output-path /dev/stdout \
  --one-shot | grep -B5 1234
2024/11/08 16:47:26 Preflight agent version: development ()
2024/11/08 16:47:26 Using the Jetstack Secure API Token auth mode since --api-token was specified.
2024/11/08 16:47:26 error messages will not show in the pod's events because the POD_NAME environment variable is empty
2024/11/08 16:47:26 starting "k8s/namespaces" datagatherer
2024/11/08 16:47:26 starting "k8s/secrets" datagatherer
2024/11/08 16:47:26 successfully gathered 7 items from "k8s/namespaces" datagatherer
2024/11/08 16:47:26 successfully gathered 5 items from "k8s/secrets" datagatherer
2024/11/08 16:47:26 Data saved to local file: /dev/stdout
          "resource": {
            "apiVersion": "v1",
            "kind": "Namespace",
            "metadata": {
              "annotations": {
                "some-secret-apikey": "1234"
              },
              "creationTimestamp": "2024-11-08T15:37:03Z",
              "labels": {
                "kubernetes.io/metadata.name": "my-ns",
                "some-secret-password": "1234"
--
              "tls.crt": "..."
            },
            "kind": "Secret",
            "metadata": {
              "annotations": {
                "some-secret-apikey": "1234"
              },
              "labels": {
                "some-secret-password": "1234"
```

### Test 2: Real API + Venafi Cloud Key Pair Service Account auth

In this test, I check that agent's HTTP request doesn't contain the annotations and labels using mitmproxy.

For this test, I've used the tenant https://ven-tlspk.venafi.cloud/. To access the API key, use the user `system.admin@tlspk.qa.venafi.io` and the password is visible in the page [Production Accounts](https://venafi.atlassian.net/wiki/spaces/CT/pages/2115404149) (private to Venafi). Then go to the settings and find the API key, and set it as an env var:

```sh
APIKEY=...
```

Create the service account and key pair:

```bash
venctl iam service-account agent create --name "$USER temp" \
  --vcp-region US \
  --output json \
  --owning-team $(curl -sS https://api.venafi.cloud/v1/teams -H "tppl-api-key: $APIKEY" | jq '.teams[0].id') \
  --output-file /tmp/agent-credentials.json \
  --api-key $APIKEY
```

Now, make sure to have `127.0.0.1 me` in your `/etc/hosts`.

Then, run mitmproxy with:

```sh
curl -L https://raw.githubusercontent.com/maelvls/kubectl-incluster/main/watch-stream.py >/tmp/watch-stream.py
mitmproxy --mode regular@9090 --ssl-insecure -s /tmp/watch-stream.py --set client_certs=$(kubectl incluster --print-client-cert >/tmp/me.pem && echo /tmp/me.pem)
```

Run this:

```bash
cat <<EOF >minimal-config.yaml
period: 5m
cluster_id: "kind-mael"
server: "https://api.venafi.cloud/"
venafi-cloud:
  upload_path: "/v1/tlspk/upload/clusterdata"
exclude-annotation-keys-regex:
  - ".*password.*"
  - ".*apikey.*"
exclude-label-keys-regex:
  - ".*password.*"
  - ".*apikey.*"
data-gatherers:
  - kind: "k8s-dynamic"
    name: "k8s/namespaces"
    config:
      resource-type:
        resource: namespaces
        version: v1
  - kind: "k8s-dynamic"
    name: "k8s/secrets"
    config:
      resource-type:
        version: v1
        resource: secrets
EOF
```

Now, don't forget to create a Kind cluster. Then:

```sh
openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=mydomain.com/O=myorganization"
kubectl create secret tls my-tls-secret --cert=tls.crt --key=tls.key
kubectl annotate secret my-tls-secret some-secret-apikey=1234
kubectl label secret my-tls-secret some-secret-password=1234

kubectl create ns my-ns
kubectl annotate ns my-ns some-secret-apikey=1234
kubectl label ns my-ns some-secret-password=1234
```

Finally, run the Agent with:

```sh
go install github.com/maelvls/kubectl-incluster@latest
export HTTPS_PROXY=http://localhost:9090 KUBECONFIG=/tmp/kube && KUBECONFIG= HTTPS_PROXY= kubectl incluster --replace-ca-cert ~/.mitmproxy/mitmproxy-ca-cert.pem --sa=venafi/venafi-kubernetes-agent | sed 's|127.0.0.1|me|' >/tmp/kube

go run . agent -c minimal-config.yaml \
  --client-id $(jq -r .client_id /tmp/agent-credentials.json) \
  --private-key-path <(jq -r .private_key /tmp/agent-credentials.json) \
  --install-namespace=venafi \
  --one-shot
```

Look at the mitmproxy logs and look for the entry that has the path

```
/v1/tlspk/upload/clusterdata/no?name=...
```

Open it (enter) and type `/` and 1234. You should not see any instance of "1234", proving that the annotations and labels have been filtered out.

When looking at the JSON blob, all of the annotations and labels containing `apikey` and `password` are gone:

| type | name | namespace | annotations | labels |
|------|------|-----------|-------------|--------|
| Namespace | local-path-storage | - | {} | {“kubernetes.io/metadata.name”: “local-path-storage”} |
| Namespace | my-ns | - | {} | {“kubernetes.io/metadata.name”: “my-ns”} |
| Namespace | venafi | - | {} | {“kubernetes.io/metadata.name”: “venafi”, “name”: “venafi”} |
| Namespace | default | - | {} | {“kubernetes.io/metadata.name”: “default”} |
| Namespace | kube-node-lease | - | {} | {“kubernetes.io/metadata.name”: “kube-node-lease”} |
| Namespace | kube-public | - | {} | {“kubernetes.io/metadata.name”: “kube-public”} |
| Namespace | kube-system | - | {} | {“kubernetes.io/metadata.name”: “kube-system”} |
| Secret | agent-credentials | venafi | {} | - |
| Secret | sh.helm.release.v1.venafi-kubernetes-agent.v1 | venafi | - | {“modifiedAt”: “1728905433”, “name”: “venafi-kubernetes-agent”, “owner”: “helm”,  |“status”: “superseded”, “version”: “1”}
| Secret | sh.helm.release.v1.venafi-kubernetes-agent.v2 | venafi | - | {“modifiedAt”: “1728905433”, “name”: “venafi-kubernetes-agent”, “owner”: “helm”,  |“status”: “superseded”, “version”: “2”}
| Secret | sh.helm.release.v1.venafi-kubernetes-agent.v3 | venafi | - | {“modifiedAt”: “1728905433”, “name”: “venafi-kubernetes-agent”, “owner”: “helm”,  |“status”: “deployed”, “version”: “3”}
| Secret | my-tls-secret | default | {} | {} |

Here is the output that I got without this PR:

| type | name | namespace | annotations | labels |
|------|------|-----------|-------------|--------|
| Namespace | default | - | - | {“kubernetes.io/metadata.name”: “default”} |
| Namespace | kube-node-lease | - | - | {“kubernetes.io/metadata.name”: “kube-node-lease”} |
| Namespace | kube-public | - | - | {“kubernetes.io/metadata.name”: “kube-public”} |
| Namespace | kube-system | - | - | {“kubernetes.io/metadata.name”: “kube-system”} |
| Namespace | local-path-storage | - | {} | {“kubernetes.io/metadata.name”: “local-path-storage”} |
| Namespace | my-ns | - | {“some-secret-apikey”: “1234”} | {“kubernetes.io/metadata.name”: “my-ns”, “some-secret-password”: “1234”} |
| Namespace | venafi | - | - | {“kubernetes.io/metadata.name”: “venafi”, “name”: “venafi”} |
| Secret | agent-credentials | venafi | {} | - |
| Secret | sh.helm.release.v1.venafi-kubernetes-agent.v1 | venafi | - | {“modifiedAt”: “1728905433”, “name”: “venafi-kubernetes-agent”, “owner”: “helm”,  |“status”: “superseded”, “version”: “1”}
| Secret | sh.helm.release.v1.venafi-kubernetes-agent.v2 | venafi | - | {“modifiedAt”: “1728905433”, “name”: “venafi-kubernetes-agent”, “owner”: “helm”,  |“status”: “superseded”, “version”: “2”}
| Secret | sh.helm.release.v1.venafi-kubernetes-agent.v3 | venafi | - | {“modifiedAt”: “1728905433”, “name”: “venafi-kubernetes-agent”, “owner”: “helm”,  |“status”: “deployed”, “version”: “3”}
| Secret | my-tls-secret | default | {“some-secret-apikey”: “1234”} | {“some-secret-password”: “1234”} |



[VC-36950]: https://venafi.atlassian.net/browse/VC-36950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ