### PR TITLE
[VC-33564] Add a Firefly clusterrole and clusterrolebinding to the venafi-kubernetes-agent chart

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
@@ -288,3 +288,30 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-firefly-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["firefly.venafi.com"]
+    resources:
+      - issuers
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-firefly-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-firefly-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This is a small part of the work to remove spurious log messages: https://venafi.atlassian.net/browse/VC-33564

In https://github.com/jetstack/jetstack-secure/pull/507 we added a Firefly datagatherer to the venafi-kubernetes-agent chart configmap, but forgot to add RBAC to allow venafi-kubernetes-agent to read the firefly issuer resources.

This causes the following errors to be logged:
> datagatherer informer has failed and is backing off
> failed to list firefly.venafi.com/v1, Resource=issuers: issuers.firefly.venafi.com is forbidden: User "system:serviceaccount:venafi:venafi-kubernetes-agent" cannot list resource "issuers" in API group "firefly.venafi.com" at the cluster scope

> k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list firefly.venafi.com/v1, Resource=issuers: issuers.firefly.venafi.com is forbidden: User "system:serviceaccount:venafi:venafi-kubernetes-agent" cannot list resource "issuers" in API group "firefly.venafi.com" at the cluster scope

Here I've manually added the missing RBAC to the Helm chart. 

<img width="960" alt="image" src="https://github.com/user-attachments/assets/e95cab18-4be8-4d2a-a7cd-b25349926cd8">


> ℹ️ I tried to write a new  `make verify` target to avoid this happening in the future, but it's complicated because venafi-kubernetes-agent relies on a binding to the generic `view` ClusterRole, to get, list, watch some of the more common API types.
> In another PR, we can remove that and instead generate the rbac using the existing `preflight agent rbac` sub-command.
You can see my attempt in https://github.com/jetstack/jetstack-secure/pull/615


