### PR TITLE
[VC-35738] Define well known log verbosity values and log less by default

### DIFF
--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/datagatherer"
+	"github.com/jetstack/preflight/pkg/logs"
 )
 
 // ConfigDynamic contains the configuration for the data-gatherer.
@@ -273,7 +274,7 @@ func (g *DataGathererDynamic) Run(stopCh <-chan struct{}) error {
 	// attach WatchErrorHandler, it needs to be set before starting an informer
 	err := g.informer.SetWatchErrorHandler(func(r *k8scache.Reflector, err error) {
 		if strings.Contains(fmt.Sprintf("%s", err), "the server could not find the requested resource") {
-			log.Info("server missing resource for datagatherer", "groupVersionResource", g.groupVersionResource)
+			log.V(logs.Debug).Info("Server missing resource for datagatherer", "groupVersionResource", g.groupVersionResource)
 		} else {
 			log.Info("datagatherer informer has failed and is backing off", "groupVersionResource", g.groupVersionResource, "reason", err)
 		}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -49,6 +49,14 @@ var (
 	features = featuregate.NewFeatureGate()
 )
 
+const (
+	// Standard log verbosity levels.
+	// Use these instead of integers in venafi-kubernetes-agent code.
+	Info  = 0
+	Debug = 1
+	Trace = 2
+)
+
 func init() {
 	runtime.Must(logsapi.AddFeatureGates(features))
 	// Turn on ALPHA options to enable the split-stream logging options.
@@ -94,6 +102,7 @@ func AddFlags(fs *pflag.FlagSet) {
 		if f.Name == "v" {
 			f.Name = "log-level"
 			f.Shorthand = "v"
+			f.Usage = fmt.Sprintf("%s. 0=Info, 1=Debug, 2=Trace. Use 3-10 for even greater detail. (default: 0)", f.Usage)
 		}
 	})
 	fs.AddFlagSet(&tfs)

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -83,7 +83,7 @@ func TestLogs(t *testing.T) {
 			name:  "help",
 			flags: "-h",
 			expectStdout: `
-  -v, --log-level Level         number for the log level verbosity
+  -v, --log-level Level         number for the log level verbosity. 0=Info, 1=Debug, 2=Trace. Use 3-10 for even greater detail. (default: 0)
       --logging-format string   Sets the log format. Permitted formats: "json", "text". (default "text")
       --vmodule pattern=N,...   comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
 `,


### PR DESCRIPTION
The aims of this PR are:
 * Make it clearer to the user what the `--verbosity` values mean in practice.
 * Make it clear what the default `--verbosity` value is.
 * Make it clearer to developers which `V()` value to use when they add new log messages.
 * Make the `V()` values more consistent.
 * Reduce the number of Info log messages that the agent prints by default.