### PR TITLE
[VC-33564] Fix the invalid API group rule for clusterrole venafi-kubernetes-agent-openshift-reader

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
@@ -213,7 +213,7 @@ metadata:
   labels:
     {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["*.openshift.io"]
+  - apiGroups: ["route.openshift.io"]
     resources:
       - routes
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
The RBAC shipped with venafi-kubernetes-agent contained a syntax error which prevents the OpenShift Routes from being collected.

Users would have seen the following errors:

> k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list route.openshift.io/v1, Resource=routes: routes.route.openshift.io is forbidden: User \"system:serviceaccount:venafi:venafi-kubernetes-agent\" cannot list resource \"routes\" in API group \"route.openshift.io\" at the cluster scope

<img width="960" alt="image" src="https://github.com/user-attachments/assets/4f83b361-b9df-4192-8315-fd651b32aa24">


The RBAC API Group field is documented as follows:

```console
$ kubectl explain clusterrole.rules.apiGroups
GROUP:      rbac.authorization.k8s.io
KIND:       ClusterRole
VERSION:    v1

FIELD: apiGroups <[]string>

DESCRIPTION:
    APIGroups is the name of the APIGroup that contains the resources.  If
    multiple API groups are specified, any action requested against one of the
    enumerated resources in any API group will be allowed. "" represents the
    core API group and "*" represents all API groups.
```

The OpenShift route CRD can be installed as follows:

```bash
kubectl apply -f https://raw.githubusercontent.com/openshift/api/release-4.18/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml
```

 * https://github.com/openshift/api/blob/master/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml