### PR TITLE
WIP: [VC-35738] Hide the client-go reflector warning logs

### DIFF
--- a/pkg/datagatherer/k8s/dynamic.go
+++ b/pkg/datagatherer/k8s/dynamic.go
@@ -277,7 +277,7 @@ func (g *DataGathererDynamic) Run(stopCh <-chan struct{}) error {
 
 	// attach WatchErrorHandler, it needs to be set before starting an informer
 	err := g.informer.SetWatchErrorHandler(func(r *k8scache.Reflector, err error) {
-		if strings.Contains(fmt.Sprintf("%s", err), "the server could not find the requested resource") {
+		if strings.Contains(err.Error(), logs.FilteredMessageReflectorFailedToList) {
 			log.V(logs.Debug).Info("Server missing resource for datagatherer", "groupVersionResource", g.groupVersionResource)
 		} else {
 			log.Info("datagatherer informer has failed and is backing off", "groupVersionResource", g.groupVersionResource, "reason", err)


### PR DESCRIPTION
The aim of this PR is to filter out the [warnings logged in client-go/tools/cache/reflector.go](https://github.com/kubernetes/client-go/blob/37045084c2aa82927b0e5ffc752861430fd7e4ab/tools/cache/reflector.go#L569) when a resource group version is not installed in the Kubernetes API server.

Hiding the warnings is achieved by creating a filtering logr.LogSink and assigning that to the default klog logger.

However it does not seem possible to maintain the correct file and line numbers when wrapping the logger this way.
I discussed this with the klog authors and they confirm that there are probably bugs in the way the klog functions unwrap the stack:
 * https://kubernetes.slack.com/archives/C20HH14P7/p1732035524601449

In that thread on Slack, I learned from the klog authors that there is an in progress PR which will remove this distracting warning message:
* https://github.com/kubernetes/kubernetes/pull/126387#pullrequestreview-2448130478

So I will close this PR.