### PR TITLE
[VC-36032] Log the client-id when VenafiCloudKeypair authentication is used

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jetstack/preflight/pkg/datagatherer/k8s"
 	"github.com/jetstack/preflight/pkg/datagatherer/local"
 	"github.com/jetstack/preflight/pkg/kubeconfig"
+	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/jetstack/preflight/pkg/version"
 )
 
@@ -370,29 +371,33 @@ func ValidateAndCombineConfig(log logr.Logger, cfg Config, flags AgentCmdFlags) 
 
 	{
 		var (
-			mode   AuthMode
-			reason string
+			mode          AuthMode
+			reason        string
+			keysAndValues []any
 		)
 		switch {
 		case flags.VenafiCloudMode && flags.CredentialsPath != "":
 			mode = VenafiCloudKeypair
-			reason = fmt.Sprintf("Using the %s auth mode since --venafi-cloud and --credentials-path were specified.", mode)
+			reason = "--venafi-cloud and --credentials-path were specified"
+			keysAndValues = []any{"credentialsPath", flags.CredentialsPath}
 		case flags.ClientID != "" && flags.PrivateKeyPath != "":
 			mode = VenafiCloudKeypair
-			reason = fmt.Sprintf("Using the %s auth mode since --client-id and --private-key-path were specified.", mode)
+			reason = "--client-id and --private-key-path were specified"
+			keysAndValues = []any{"clientID", flags.ClientID, "privateKeyPath", flags.PrivateKeyPath}
 		case flags.ClientID != "":
 			return CombinedConfig{}, nil, fmt.Errorf("if --client-id is specified, --private-key-path must also be specified")
 		case flags.PrivateKeyPath != "":
 			return CombinedConfig{}, nil, fmt.Errorf("--private-key-path is specified, --client-id must also be specified")
 		case flags.VenConnName != "":
 			mode = VenafiCloudVenafiConnection
-			reason = fmt.Sprintf("Using the %s auth mode since --venafi-connection was specified.", mode)
+			reason = "--venafi-connection was specified"
+			keysAndValues = []any{"venConnName", flags.VenConnName}
 		case flags.APIToken != "":
 			mode = JetstackSecureAPIToken
-			reason = fmt.Sprintf("Using the %s auth mode since --api-token was specified.", mode)
+			reason = "--api-token was specified"
 		case !flags.VenafiCloudMode && flags.CredentialsPath != "":
 			mode = JetstackSecureOAuth
-			reason = fmt.Sprintf("Using the %s auth mode since --credentials-file was specified without --venafi-cloud.", mode)
+			reason = "--credentials-file was specified without --venafi-cloud"
 		default:
 			return CombinedConfig{}, nil, fmt.Errorf("no auth mode specified. You can use one of four auth modes:\n" +
 				" - Use (--venafi-cloud with --credentials-file) or (--client-id with --private-key-path) to use the " + string(VenafiCloudKeypair) + " mode.\n" +
@@ -401,7 +406,8 @@ func ValidateAndCombineConfig(log logr.Logger, cfg Config, flags AgentCmdFlags) 
 				" - Use --api-token if you want to use the " + string(JetstackSecureAPIToken) + " mode.\n")
 		}
 		res.AuthMode = mode
-		log.Info(reason)
+		keysAndValues = append(keysAndValues, "mode", mode, "reason", reason)
+		log.V(logs.Debug).Info("Authentication mode", keysAndValues...)
 	}
 
 	// Validation and defaulting of `server` and the deprecated `endpoint.path`.

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -98,7 +98,7 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 			withCmdLineFlags("--period", "99m", "--credentials-file", fakeCredsPath))
 		require.NoError(t, err)
 		assert.Equal(t, testutil.Undent(`
-			INFO Using the Jetstack Secure OAuth auth mode since --credentials-file was specified without --venafi-cloud.
+			INFO Authentication mode mode="Jetstack Secure OAuth" reason="--credentials-file was specified without --venafi-cloud"
 			INFO Both the 'period' field and --period are set. Using the value provided with --period.
 		`), gotLogs.String())
 		assert.Equal(t, 99*time.Minute, got.Period)
@@ -588,7 +588,7 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.Equal(t, testutil.Undent(`
-			INFO Using the Venafi Cloud VenafiConnection auth mode since --venafi-connection was specified.
+			INFO Authentication mode venConnName="venafi-components" mode="Venafi Cloud VenafiConnection" reason="--venafi-connection was specified"
 			INFO ignoring the server field specified in the config file. In Venafi Cloud VenafiConnection mode, this field is not needed.
 			INFO ignoring the venafi-cloud.upload_path field in the config file. In Venafi Cloud VenafiConnection mode, this field is not needed.
 			INFO ignoring the venafi-cloud.uploader_id field in the config file. This field is not needed in Venafi Cloud VenafiConnection mode.


### PR DESCRIPTION
In https://github.com/jetstack/jetstack-secure/issues/549 @hawksight wrote:
> ...we are missing one important piece [of logged information] when connecting to TLSPK on VCP, the client-id

I've added client-id to the log messages when the configuration resolver selects Venafi Cloud Authentication.

But in the interests of reducing the overwhelming quantity of log messages, I've also changed that log message to only be shown at debug log level `--log-level=1`.

I've also associated this PR with `[VC-36032] AGENT: Enhanced troubleshooting through improved logging`.


## Testing


```console
$ go run ./ agent --install-namespace default --private-key-path /dev/null --client-id foo --agent-config-file examples/cert-manager-agent.yaml  --output-path /dev/null -v1
I1120 15:50:50.273235  185320 run.go:59] "Starting" logger="Run" version="development" commit=""
I1120 15:50:50.280681  185320 config.go:410] "Authentication mode" logger="Run" clientID="foo" privateKeyPath="/dev/null" mode="Venafi Cloud Key Pair Service Account" reason="--client-id and --private-key-path were specified"
I1120 15:50:50.280752  185320 config.go:428] "Using deprecated Endpoint configuration. User Server instead." logger="Run"
E1120 15:50:50.280799  185320 root.go:53] "Exiting due to error" err=<
        While evaluating configuration: 2 errors occurred:
                * the venafi-cloud.upload_path field is required when using the Venafi Cloud Key Pair Service Account mode
                * period must be set using --period or -p, or using the 'period' field in the config file

 > exit-code=1
exit status 1
```

```console
$ go test -v ./pkg/agent/... -run  Test_ValidateAndCombineConfig | grep "Authentication mode"
    config.go:410: I1120 15:54:40.370580] Authentication mode mode="Jetstack Secure OAuth" reason="--credentials-file was specified without --venafi-cloud"
    config.go:410: I1120 15:54:40.415486] Authentication mode venConnName="venafi-components" mode="Venafi Cloud VenafiConnection" reason="--venafi-connection was specified"
```


[VC-36032]: https://venafi.atlassian.net/browse/VC-36032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ