### PR TITLE
[VC-36032] Configure controller-runtime to log with klog

### DIFF
--- a/hack/e2e/values.venafi-kubernetes-agent.yaml
+++ b/hack/e2e/values.venafi-kubernetes-agent.yaml
@@ -10,3 +10,4 @@ authentication:
 
 extraArgs:
 - --logging-format=json
+- --log-level=2

--- a/pkg/client/client_venconn.go
+++ b/pkg/client/client_venconn.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-logr/logr"
 	venapi "github.com/jetstack/venafi-connection-lib/api/v1alpha1"
 	"github.com/jetstack/venafi-connection-lib/venafi_client"
 	"github.com/jetstack/venafi-connection-lib/venafi_client/auth"
@@ -22,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/jetstack/preflight/api"
 	"github.com/jetstack/preflight/pkg/version"
@@ -57,11 +55,6 @@ type VenConnClient struct {
 // `restcfg` is not mutated. `trustedCAs` is only used for connecting to Venafi
 // Cloud and Vault and can be left nil.
 func NewVenConnClient(restcfg *rest.Config, agentMetadata *api.AgentMetadata, installNS, venConnName, venConnNS string, trustedCAs *x509.CertPool, disableCompression bool) (*VenConnClient, error) {
-	// TODO(mael): The rest of the codebase uses the standard "log" package,
-	// venafi-connection-lib uses "go-logr/logr", and client-go uses "klog". We
-	// should standardize on one of them, probably "slog".
-	ctrlruntimelog.SetLogger(logr.Logger{})
-
 	if installNS == "" {
 		return nil, errors.New("programmer mistake: installNS must be provided")
 	}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/klog/v2"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // venafi-kubernetes-agent follows [Kubernetes Logging Conventions] and writes
@@ -131,6 +133,11 @@ func Initialize() error {
 	// to the global log logger. It can be removed when this is fixed upstream
 	// in vcert:  https://github.com/Venafi/vcert/pull/512
 	vcertLog.SetPrefix("")
+
+	// The venafi-connection-lib client uses various controller-runtime packages
+	// which emit log messages. Make sure those log messages are not discarded.
+	ctrlruntimelog.SetLogger(klog.Background().WithValues("source", "controller-runtime"))
+
 	return nil
 }
 


### PR DESCRIPTION
I assume that the controller-runtime logs were being discarded.
With this change I hope to find some controller-runtime logs among the e2e test logs.

## Testing

```console
$ make test-e2e-gke
...
{
  "ts": 1732123466929.3813,
  "caller": "metrics/metrics.go:97",
  "msg": "cache not synced yet, skipping metrics venaficonnection_*",
  "source": "controller-runtime",
  "v": 0
}
...
{"ts":1732123472568.4834,"caller":"agent/run.go:409","msg":"Data sent successfully","v":0,"logger":"Run.gatherAndOutputData.postData"}
```

That single message seems to come from venafi-connection-lib, so perhaps it's misleading to label these logs with `source: "controller-runtime"`:
 * https://github.com/jetstack/venafi-connection-lib/pull/146
 * https://github.com/jetstack/venafi-connection-lib/blob/13c2342fe0140ff084d2aabfd29ae3d10721691b/internal/metrics/metrics.go#L92-L102

@maelvls Does that log message indicate a bug in the way we're instantiating the venafi-connection-lib client?