### PR TITLE
[VC-36032] Pass the context to Venafi clients and enable debug roundtripper

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -265,8 +265,18 @@ Specify the command to run overriding default binary.
 > []
 > ```
 
-Specify additional arguments to pass to the agent binary.  
-Example: `["--strict", "--oneshot"]`
+Specify additional arguments to pass to the agent binary. For example, to enable JSON logging use `--logging-format`, or to increase the logging verbosity use `--log-level`.  
+The log levels are: 0=Info, 1=Debug, 2=Trace.  
+Use 6-9 for increasingly verbose HTTP request logging.  
+The default log level is 0.  
+  
+Example:
+
+```yaml
+extraArgs:
+- --logging-format=json
+- --log-level=6 # To enable HTTP request logging
+```
 #### **volumes** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/venafi-kubernetes-agent/values.schema.json
+++ b/deploy/charts/venafi-kubernetes-agent/values.schema.json
@@ -308,7 +308,7 @@
     },
     "helm-values.extraArgs": {
       "default": [],
-      "description": "Specify additional arguments to pass to the agent binary.\nExample: `[\"--strict\", \"--oneshot\"]`",
+      "description": "Specify additional arguments to pass to the agent binary. For example, to enable JSON logging use `--logging-format`, or to increase the logging verbosity use `--log-level`.\nThe log levels are: 0=Info, 1=Debug, 2=Trace.\nUse 6-9 for increasingly verbose HTTP request logging.\nThe default log level is 0.\n\nExample:\nextraArgs:\n- --logging-format=json\n- --log-level=6 # To enable HTTP request logging",
       "items": {},
       "type": "array"
     },

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -146,7 +146,16 @@ affinity: {}
 command: []
 
 # Specify additional arguments to pass to the agent binary.
-# Example: `["--strict", "--oneshot"]`
+# For example, to enable JSON logging use `--logging-format`, or
+# to increase the logging verbosity use `--log-level`.
+# The log levels are: 0=Info, 1=Debug, 2=Trace.
+# Use 6-9 for increasingly verbose HTTP request logging.
+# The default log level is 0.
+#
+# Example:
+#  extraArgs:
+#  - --logging-format=json
+#  - --log-level=6 # To enable HTTP request logging
 extraArgs: []
 
 # Additional volumes to add to the Venafi Kubernetes Agent container. This is

--- a/hack/e2e/values.venafi-kubernetes-agent.yaml
+++ b/hack/e2e/values.venafi-kubernetes-agent.yaml
@@ -10,4 +10,4 @@ authentication:
 
 extraArgs:
 - --logging-format=json
-- --log-level=2
+- --log-level=6

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -750,7 +750,7 @@ func Test_ValidateAndCombineConfig_VenafiConnection(t *testing.T) {
 			withCmdLineFlags("--venafi-connection", "venafi-components", "--install-namespace", "venafi"))
 		require.NoError(t, err)
 
-		testutil.VenConnStartWatching(t, cl)
+		testutil.VenConnStartWatching(ctx, t, cl)
 		testutil.TrustCA(t, cl, cert)
 
 		// TODO(mael): the client should keep track of the cluster ID, we

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 
 	"github.com/jetstack/preflight/pkg/client"
@@ -620,6 +621,12 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 func Test_ValidateAndCombineConfig_VenafiCloudKeyPair(t *testing.T) {
 	t.Run("server, uploader_id, and cluster name are correctly passed", func(t *testing.T) {
 		t.Setenv("POD_NAMESPACE", "venafi")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		log := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(10)))
+		ctx = klog.NewContext(ctx, log)
+
 		srv, cert, setVenafiCloudAssert := testutil.FakeVenafiCloud(t)
 		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
 			// Only care about /v1/tlspk/upload/clusterdata/:uploader_id?name=
@@ -648,7 +655,7 @@ func Test_ValidateAndCombineConfig_VenafiCloudKeyPair(t *testing.T) {
 		testutil.TrustCA(t, cl, cert)
 		assert.Equal(t, VenafiCloudKeypair, got.AuthMode)
 
-		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: "test cluster name"})
+		err = cl.PostDataReadingsWithOptions(ctx, nil, client.Options{ClusterName: "test cluster name"})
 		require.NoError(t, err)
 	})
 }
@@ -724,6 +731,11 @@ func Test_ValidateAndCombineConfig_VenafiConnection(t *testing.T) {
 	})
 
 	t.Run("the server field is ignored when VenafiConnection is used", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		log := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(10)))
+		ctx = klog.NewContext(ctx, log)
+
 		expected := srv.URL
 		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
 			assert.Equal(t, expected, "https://"+gotReq.Host)
@@ -744,7 +756,7 @@ func Test_ValidateAndCombineConfig_VenafiConnection(t *testing.T) {
 		// TODO(mael): the client should keep track of the cluster ID, we
 		// shouldn't need to pass it as an option to
 		// PostDataReadingsWithOptions.
-		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: cfg.ClusterID})
+		err = cl.PostDataReadingsWithOptions(ctx, nil, client.Options{ClusterName: cfg.ClusterID})
 		require.NoError(t, err)
 	})
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,9 +30,9 @@ type (
 
 	// The Client interface describes types that perform requests against the Jetstack Secure backend.
 	Client interface {
-		PostDataReadings(orgID, clusterID string, readings []*api.DataReading) error
-		PostDataReadingsWithOptions(readings []*api.DataReading, options Options) error
-		Post(path string, body io.Reader) (*http.Response, error)
+		PostDataReadings(ctx context.Context, orgID, clusterID string, readings []*api.DataReading) error
+		PostDataReadingsWithOptions(ctx context.Context, readings []*api.DataReading, options Options) error
+		Post(ctx context.Context, path string, body io.Reader) (*http.Response, error)
 	}
 
 	// The Credentials interface describes methods for credential types to implement for verification.

--- a/pkg/client/client_venconn_test.go
+++ b/pkg/client/client_venconn_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/jetstack/preflight/api"
@@ -34,13 +36,17 @@ import (
 //
 // [1] https://github.com/kubernetes-sigs/controller-runtime/issues/2341
 func TestVenConnClient_PostDataReadingsWithOptions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	log := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(10)))
+	ctx = klog.NewContext(ctx, log)
 	_, restconf, kclient := testutil.WithEnvtest(t)
 	for _, obj := range testutil.Parse(testutil.VenConnRBAC) {
-		require.NoError(t, kclient.Create(context.Background(), obj))
+		require.NoError(t, kclient.Create(ctx, obj))
 	}
 	t.Parallel()
 
-	t.Run("valid accessToken", run_TestVenConnClient_PostDataReadingsWithOptions(restconf, kclient, testcase{
+	t.Run("valid accessToken", run_TestVenConnClient_PostDataReadingsWithOptions(ctx, restconf, kclient, testcase{
 		given: testutil.Undent(`
 			apiVersion: jetstack.io/v1alpha1
 			kind: VenafiConnection
@@ -93,7 +99,7 @@ func TestVenConnClient_PostDataReadingsWithOptions(t *testing.T) {
 		`),
 		expectReadyCondMsg: "ea744d098c2c1c6044e4c4e9d3bf7c2a68ef30553db00f1714886cedf73230f1",
 	}))
-	t.Run("error when the apiKey field is used", run_TestVenConnClient_PostDataReadingsWithOptions(restconf, kclient, testcase{
+	t.Run("error when the apiKey field is used", run_TestVenConnClient_PostDataReadingsWithOptions(ctx, restconf, kclient, testcase{
 		// Why isn't it possible to use the 'apiKey' field? Although the
 		// Kubernetes Discovery endpoint works with an API key, we have decided
 		// to not support it because it isn't recommended.
@@ -152,7 +158,7 @@ func TestVenConnClient_PostDataReadingsWithOptions(t *testing.T) {
 		expectReadyCondMsg: "b099d634ccec56556da28028743475dab67f79d079b668bedc3ef544f7eed2f3",
 		expectErr:          "VenafiConnection error-when-the-apikey-field-is-used/venafi-components: the agent cannot be used with an API key",
 	}))
-	t.Run("error when the tpp field is used", run_TestVenConnClient_PostDataReadingsWithOptions(restconf, kclient, testcase{
+	t.Run("error when the tpp field is used", run_TestVenConnClient_PostDataReadingsWithOptions(ctx, restconf, kclient, testcase{
 		// IMPORTANT: The user may think they can use 'tpp', spend time
 		// debugging and making the venafi connection work, and then find out
 		// that it doesn't work. The reason is because as of now, we don't first
@@ -220,10 +226,11 @@ type testcase struct {
 
 // All tests share the same envtest (i.e., the same apiserver and etcd process),
 // so each test needs to be contained in its own Kubernetes namespace.
-func run_TestVenConnClient_PostDataReadingsWithOptions(restcfg *rest.Config, kclient ctrlruntime.WithWatch, test testcase) func(t *testing.T) {
+func run_TestVenConnClient_PostDataReadingsWithOptions(ctx context.Context, restcfg *rest.Config, kclient ctrlruntime.WithWatch, test testcase) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
-
+		log := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(10)))
+		ctx := klog.NewContext(ctx, log)
 		fakeVenafiCloud, certCloud, fakeVenafiAssert := testutil.FakeVenafiCloud(t)
 		fakeTPP, certTPP := testutil.FakeTPP(t)
 		fakeVenafiAssert(func(t testing.TB, r *http.Request) {
@@ -263,10 +270,9 @@ func run_TestVenConnClient_PostDataReadingsWithOptions(restcfg *rest.Config, kcl
 			  name: `+testNameToNamespace(t)))...)
 		givenObjs = append(givenObjs, testutil.Parse(test.given)...)
 		for _, obj := range givenObjs {
-			require.NoError(t, kclient.Create(context.Background(), obj))
+			require.NoError(t, kclient.Create(ctx, obj))
 		}
-
-		err = cl.PostDataReadingsWithOptions([]*api.DataReading{}, client.Options{ClusterName: "test cluster name"})
+		err = cl.PostDataReadingsWithOptions(ctx, []*api.DataReading{}, client.Options{ClusterName: "test cluster name"})
 		if test.expectErr != "" {
 			assert.EqualError(t, err, test.expectErr)
 		} else {
@@ -274,7 +280,7 @@ func run_TestVenConnClient_PostDataReadingsWithOptions(restcfg *rest.Config, kcl
 		}
 
 		got := v1alpha1.VenafiConnection{}
-		err = kclient.Get(context.Background(), types.NamespacedName{Name: "venafi-components", Namespace: testNameToNamespace(t)}, &got)
+		err = kclient.Get(ctx, types.NamespacedName{Name: "venafi-components", Namespace: testNameToNamespace(t)}, &got)
 		require.NoError(t, err)
 		require.Len(t, got.Status.Conditions, 1)
 		assert.Equal(t, test.expectReadyCondMsg, got.Status.Conditions[0].Message)

--- a/pkg/client/client_venconn_test.go
+++ b/pkg/client/client_venconn_test.go
@@ -256,7 +256,7 @@ func run_TestVenConnClient_PostDataReadingsWithOptions(ctx context.Context, rest
 		)
 		require.NoError(t, err)
 
-		testutil.VenConnStartWatching(t, cl)
+		testutil.VenConnStartWatching(ctx, t, cl)
 
 		test.given = strings.ReplaceAll(test.given, "FAKE_VENAFI_CLOUD_URL", fakeVenafiCloud.URL)
 		test.given = strings.ReplaceAll(test.given, "FAKE_TPP_URL", fakeTPP.URL)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -104,7 +104,7 @@ func AddFlags(fs *pflag.FlagSet) {
 		if f.Name == "v" {
 			f.Name = "log-level"
 			f.Shorthand = "v"
-			f.Usage = fmt.Sprintf("%s. 0=Info, 1=Debug, 2=Trace. Use 3-10 for even greater detail. (default: 0)", f.Usage)
+			f.Usage = fmt.Sprintf("%s. 0=Info, 1=Debug, 2=Trace. Use 6-9 for increasingly verbose HTTP request logging. (default: 0)", f.Usage)
 		}
 	})
 	fs.AddFlagSet(&tfs)

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -83,7 +83,7 @@ func TestLogs(t *testing.T) {
 			name:  "help",
 			flags: "-h",
 			expectStdout: `
-  -v, --log-level Level         number for the log level verbosity. 0=Info, 1=Debug, 2=Trace. Use 3-10 for even greater detail. (default: 0)
+  -v, --log-level Level         number for the log level verbosity. 0=Info, 1=Debug, 2=Trace. Use 6-9 for increasingly verbose HTTP request logging. (default: 0)
       --logging-format string   Sets the log format. Permitted formats: "json", "text". (default "text")
       --vmodule pattern=N,...   comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
 `,

--- a/pkg/testutil/envtest.go
+++ b/pkg/testutil/envtest.go
@@ -106,7 +106,7 @@ func WithKubeconfig(t testing.TB, restCfg *rest.Config) string {
 // Tests calling to VenConnClient.PostDataReadingsWithOptions must call this
 // function to start the VenafiConnection watcher. If you don't call this, the
 // test will stall.
-func VenConnStartWatching(t *testing.T, cl client.Client) {
+func VenConnStartWatching(ctx context.Context, t *testing.T, cl client.Client) {
 	t.Helper()
 
 	require.IsType(t, &client.VenConnClient{}, cl)
@@ -116,7 +116,7 @@ func VenConnStartWatching(t *testing.T, cl client.Client) {
 	// the message "timeout waiting for process kube-apiserver to stop". See:
 	// https://github.com/jetstack/venafi-connection-lib/pull/158#issuecomment-1949002322
 	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571#issuecomment-945535598
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	go func() {
 		err := cl.(*client.VenConnClient).Start(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
- Improve orderly shutdown by abandoning ongoing requests to Venafi when the context is cancelled
- Make it easier to debug venafi data upload problems by allowing the request details to be logged with `--log-level=6`.

```bash
go run . agent --install-namespace venafi --one-shot --input-path out.json  --venafi-connection venafi-components -v6
```


> I1127 09:58:16.779115  318776 metrics_transport.go:113] "outgoing http request succeeded" source="controller-runtime" method="POST" uri="https://api.venafi.eu/v1/oauth2/v2.0/9a0cab61-2b00-11ee-ba09-0733b0fe5adc/token" status="200 OK" duration="582.557289ms"
> **I1127 09:58:17.313520  318776 round_trippers.go:553] POST https://api.venafi.eu/v1/tlspk/upload/clusterdata/no?name=my_cluster 200 OK in 502 milliseconds**
> I1127 09:58:17.313624  318776 run.go:405] "Data sent successfully" logger="Run.gatherAndOutputData.postData"

> W1127 09:58:17.313811  318776 reflector.go:484] pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: watch of *v1alpha1.VenafiConnection ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
> I1127 09:58:17.313874  318776 reflector.go:311] Stopping reflector *v1alpha1.VenafiConnection (10h1m26.347417125s) from pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243
> I1127 09:58:17.313899  318776 run.go:484] "Shutting down" logger="Run.APIServer.ListenAndServe" addr=":8081"
> I1127 09:58:17.314047  318776 run.go:499] "Shutdown complete" logger="Run.APIServer.ListenAndServe" addr=":8081"
> 