### PR TITLE
VC-37264: Disable compression to give us time to work on a fix

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -168,9 +168,8 @@ type AgentCmdFlags struct {
 	// Prometheus (--enable-metrics) enables the Prometheus metrics server.
 	Prometheus bool
 
-	// DisableCompression (--disable-compression) disables the GZIP compression
-	// when uploading the data. Useful for debugging purposes, or when an
-	// intermediate proxy doesn't like compressed data.
+	// DisableCompression (--disable-compression) is deprecated and no longer
+	// has an effect.
 	DisableCompression bool
 }
 
@@ -304,6 +303,7 @@ func InitAgentCmdFlags(c *cobra.Command, cfg *AgentCmdFlags) {
 		false,
 		"Deprecated. No longer has an effect.",
 	)
+	c.PersistentFlags().MarkHidden("disable-compression")
 }
 
 type AuthMode string

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -167,10 +167,6 @@ type AgentCmdFlags struct {
 
 	// Prometheus (--enable-metrics) enables the Prometheus metrics server.
 	Prometheus bool
-
-	// DisableCompression (--disable-compression) is deprecated and no longer
-	// has an effect.
-	DisableCompression bool
 }
 
 func InitAgentCmdFlags(c *cobra.Command, cfg *AgentCmdFlags) {
@@ -297,13 +293,15 @@ func InitAgentCmdFlags(c *cobra.Command, cfg *AgentCmdFlags) {
 		"Enables Prometheus metrics server on the agent (port: 8081).",
 	)
 
+	var dummy bool
 	c.PersistentFlags().BoolVar(
-		&cfg.DisableCompression,
+		&dummy,
 		"disable-compression",
 		false,
 		"Deprecated. No longer has an effect.",
 	)
-	c.PersistentFlags().MarkHidden("disable-compression")
+	c.PersistentFlags().MarkDeprecated("disable-compression", "no longer has an effect")
+
 }
 
 type AuthMode string
@@ -582,13 +580,6 @@ func ValidateAndCombineConfig(log logr.Logger, cfg Config, flags AgentCmdFlags) 
 		}
 		if flags.InputPath != "" {
 			res.InputPath = flags.InputPath
-		}
-	}
-
-	// Validation of --disable-compression.
-	{
-		if flags.DisableCompression {
-			log.Info("The flag --disable-compression has been deprecated an no longer has any effect.")
 		}
 	}
 

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -302,7 +302,7 @@ func InitAgentCmdFlags(c *cobra.Command, cfg *AgentCmdFlags) {
 		&cfg.DisableCompression,
 		"disable-compression",
 		false,
-		"Disables GZIP compression when uploading the data. Useful for debugging purposes or when an intermediate proxy doesn't like compressed data.",
+		"Deprecated. No longer has an effect.",
 	)
 }
 
@@ -346,7 +346,6 @@ type CombinedConfig struct {
 	VenConnNS   string
 
 	// VenafiCloudKeypair and VenafiCloudVenafiConnection modes only.
-	DisableCompression         bool
 	ExcludeAnnotationKeysRegex []*regexp.Regexp
 	ExcludeLabelKeysRegex      []*regexp.Regexp
 
@@ -588,10 +587,9 @@ func ValidateAndCombineConfig(log logr.Logger, cfg Config, flags AgentCmdFlags) 
 
 	// Validation of --disable-compression.
 	{
-		if flags.DisableCompression && res.AuthMode != VenafiCloudKeypair && res.AuthMode != VenafiCloudVenafiConnection {
-			errs = multierror.Append(errs, fmt.Errorf("--disable-compression can only be used with the %s and %s modes", VenafiCloudKeypair, VenafiCloudVenafiConnection))
+		if flags.DisableCompression {
+			log.Info("The flag --disable-compression has been deprecated an no longer has any effect.")
 		}
-		res.DisableCompression = flags.DisableCompression
 	}
 
 	// Validation of the config fields exclude_annotation_keys_regex and
@@ -709,7 +707,7 @@ func validateCredsAndCreateClient(log logr.Logger, flagCredentialsPath, flagClie
 			break // Don't continue with the client if kubeconfig wasn't loaded.
 		}
 
-		preflightClient, err = client.NewVenConnClient(restCfg, metadata, cfg.InstallNS, cfg.VenConnName, cfg.VenConnNS, nil, cfg.DisableCompression)
+		preflightClient, err = client.NewVenConnClient(restCfg, metadata, cfg.InstallNS, cfg.VenConnName, cfg.VenConnNS, nil)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
@@ -767,7 +765,7 @@ func createCredentialClient(log logr.Logger, credentials client.Credentials, cfg
 			log.Info("Loading upload_path from \"venafi-cloud\" configuration.")
 			uploadPath = cfg.UploadPath
 		}
-		return client.NewVenafiCloudClient(agentMetadata, creds, cfg.Server, uploaderID, uploadPath, cfg.DisableCompression)
+		return client.NewVenafiCloudClient(agentMetadata, creds, cfg.Server, uploaderID, uploadPath)
 
 	case *client.OAuthCredentials:
 		return client.NewOAuthClient(agentMetadata, creds, cfg.Server)

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -174,10 +174,11 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 				`)),
 			withCmdLineFlags("--disable-compression", "--credentials-file", path, "--install-namespace", "venafi"))
 		require.NoError(t, err)
+
+		// The log line printed by pflag is not captured by the log recorder.
 		assert.Equal(t, testutil.Undent(`
 			INFO Using the Jetstack Secure OAuth auth mode since --credentials-file was specified without --venafi-cloud.
 			INFO Using period from config period="1h0m0s"
-			INFO The flag --disable-compression has been deprecated an no longer has any effect.
 		`), b.String())
 	})
 

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -1,11 +1,8 @@
 package agent
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -163,6 +160,25 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 			withCmdLineFlags("--strict", "--credentials-file", fakeCredsPath))
 		require.NoError(t, gotErr)
 		assert.Equal(t, true, got.StrictMode)
+	})
+
+	t.Run("--disable-compression is deprecated and doesn't do anything", func(t *testing.T) {
+		path := withFile(t, `{"user_id":"fpp2624799349@affectionate-hertz6.platform.jetstack.io","user_secret":"foo","client_id": "k3TrDbfLhCgnpAbOiiT2kIE1AbovKzjo","client_secret": "f39w_3KT9Vp0VhzcPzvh-uVbudzqCFmHER3Huj0dvHgJwVrjxsoOQPIw_1SDiCfa","auth_server_domain":"auth.jetstack.io"}`)
+		log, b := recordLogs(t)
+		_, _, err := ValidateAndCombineConfig(log,
+			withConfig(testutil.Undent(`
+				server: https://api.venafi.eu
+				period: 1h
+				organization_id: foo
+				cluster_id: bar
+				`)),
+			withCmdLineFlags("--disable-compression", "--credentials-file", path, "--install-namespace", "venafi"))
+		require.NoError(t, err)
+		assert.Equal(t, testutil.Undent(`
+			INFO Using the Jetstack Secure OAuth auth mode since --credentials-file was specified without --venafi-cloud.
+			INFO Using period from config period="1h0m0s"
+			INFO The flag --disable-compression has been deprecated an no longer has any effect.
+		`), b.String())
 	})
 
 	t.Run("error when no auth method specified", func(t *testing.T) {
@@ -373,19 +389,6 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, CombinedConfig{Server: "https://api.venafi.eu", Period: time.Hour, OrganizationID: "foo", ClusterID: "bar", AuthMode: JetstackSecureOAuth, BackoffMaxTime: 10 * time.Minute, InstallNS: "venafi"}, got)
 		assert.IsType(t, &client.OAuthClient{}, cl)
-	})
-
-	t.Run("jetstack-secure-oauth-auth: can't use --disable-compression", func(t *testing.T) {
-		path := withFile(t, `{"user_id":"fpp2624799349@affectionate-hertz6.platform.jetstack.io","user_secret":"foo","client_id": "k3TrDbfLhCgnpAbOiiT2kIE1AbovKzjo","client_secret": "f39w_3KT9Vp0VhzcPzvh-uVbudzqCFmHER3Huj0dvHgJwVrjxsoOQPIw_1SDiCfa","auth_server_domain":"auth.jetstack.io"}`)
-		_, _, err := ValidateAndCombineConfig(discardLogs(),
-			withConfig(testutil.Undent(`
-				server: https://api.venafi.eu
-				period: 1h
-				organization_id: foo
-				cluster_id: bar
-				`)),
-			withCmdLineFlags("--disable-compression", "--credentials-file", path, "--install-namespace", "venafi"))
-		require.EqualError(t, err, "1 error occurred:\n\t* --disable-compression can only be used with the Venafi Cloud Key Pair Service Account and Venafi Cloud VenafiConnection modes\n\n")
 	})
 
 	t.Run("jetstack-secure-oauth-auth: --credential-file used but file is missing", func(t *testing.T) {
@@ -647,83 +650,6 @@ func Test_ValidateAndCombineConfig_VenafiCloudKeyPair(t *testing.T) {
 		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: "test cluster name"})
 		require.NoError(t, err)
 	})
-
-	t.Run("the request body is compressed", func(t *testing.T) {
-		srv, cert, setVenafiCloudAssert := testutil.FakeVenafiCloud(t)
-		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
-			if gotReq.URL.Path == "/v1/oauth/token/serviceaccount" {
-				return
-			}
-			assert.Equal(t, "/v1/tlspk/upload/clusterdata/no", gotReq.URL.Path)
-
-			// Let's check that the body is compressed as expected.
-			assert.Equal(t, "gzip", gotReq.Header.Get("Content-Encoding"))
-			uncompressR, err := gzip.NewReader(gotReq.Body)
-			require.NoError(t, err, "body might not be compressed")
-			defer uncompressR.Close()
-			uncompressed, err := io.ReadAll(uncompressR)
-			require.NoError(t, err)
-			assert.Contains(t, string(uncompressed), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
-		})
-		privKeyPath := withFile(t, fakePrivKeyPEM)
-		got, cl, err := ValidateAndCombineConfig(discardLogs(),
-			withConfig(testutil.Undent(`
-				server: `+srv.URL+`
-				period: 1h
-				cluster_id: "test cluster name"
-				venafi-cloud:
-				  uploader_id: no
-				  upload_path: /v1/tlspk/upload/clusterdata
-			`)),
-			withCmdLineFlags("--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath, "--install-namespace", "venafi"),
-		)
-		require.NoError(t, err)
-		testutil.TrustCA(t, cl, cert)
-		assert.Equal(t, VenafiCloudKeypair, got.AuthMode)
-		require.NoError(t, err)
-
-		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: "test cluster name"})
-		require.NoError(t, err)
-	})
-
-	t.Run("--disable-compression works", func(t *testing.T) {
-		srv, cert, setVenafiCloudAssert := testutil.FakeVenafiCloud(t)
-		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
-			// Only care about /v1/tlspk/upload/clusterdata/:uploader_id?name=
-			if gotReq.URL.Path == "/v1/oauth/token/serviceaccount" {
-				return
-			}
-
-			assert.Equal(t, "/v1/tlspk/upload/clusterdata/no", gotReq.URL.Path)
-
-			// Let's check that the body isn't compressed.
-			assert.Equal(t, "", gotReq.Header.Get("Content-Encoding"))
-			b := new(bytes.Buffer)
-			_, err := b.ReadFrom(gotReq.Body)
-			require.NoError(t, err)
-			assert.Contains(t, b.String(), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
-		})
-
-		privKeyPath := withFile(t, fakePrivKeyPEM)
-		got, cl, err := ValidateAndCombineConfig(discardLogs(),
-			withConfig(testutil.Undent(`
-				server: `+srv.URL+`
-				period: 1h
-				cluster_id: "test cluster name"
-				venafi-cloud:
-				  uploader_id: no
-				  upload_path: /v1/tlspk/upload/clusterdata
-			`)),
-			withCmdLineFlags("--disable-compression", "--client-id", "5bc7d07c-45da-11ef-a878-523f1e1d7de1", "--private-key-path", privKeyPath, "--install-namespace", "venafi"),
-		)
-		require.NoError(t, err)
-		testutil.TrustCA(t, cl, cert)
-		assert.Equal(t, VenafiCloudKeypair, got.AuthMode)
-		require.NoError(t, err)
-
-		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: "test cluster name"})
-		require.NoError(t, err)
-	})
 }
 
 // Slower test cases due to envtest. That's why they are separated from the
@@ -817,53 +743,6 @@ func Test_ValidateAndCombineConfig_VenafiConnection(t *testing.T) {
 		// TODO(mael): the client should keep track of the cluster ID, we
 		// shouldn't need to pass it as an option to
 		// PostDataReadingsWithOptions.
-		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: cfg.ClusterID})
-		require.NoError(t, err)
-	})
-
-	t.Run("the request is compressed by default", func(t *testing.T) {
-		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
-			// Let's check that the body is compressed as expected.
-			assert.Equal(t, "gzip", gotReq.Header.Get("Content-Encoding"))
-			uncompressR, err := gzip.NewReader(gotReq.Body)
-			require.NoError(t, err, "body might not be compressed")
-			defer uncompressR.Close()
-			uncompressed, err := io.ReadAll(uncompressR)
-			require.NoError(t, err)
-			assert.Contains(t, string(uncompressed), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
-		})
-		cfg, cl, err := ValidateAndCombineConfig(discardLogs(),
-			withConfig(testutil.Undent(`
-				period: 1h
-				cluster_id: test cluster name
-			`)),
-			withCmdLineFlags("--venafi-connection", "venafi-components", "--install-namespace", "venafi"))
-		require.NoError(t, err)
-		testutil.VenConnStartWatching(t, cl)
-		testutil.TrustCA(t, cl, cert)
-		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: cfg.ClusterID})
-		require.NoError(t, err)
-	})
-
-	t.Run("--disable-compression works", func(t *testing.T) {
-		setVenafiCloudAssert(func(t testing.TB, gotReq *http.Request) {
-			// Let's check that the body isn't compressed.
-			assert.Equal(t, "", gotReq.Header.Get("Content-Encoding"))
-			b := new(bytes.Buffer)
-			_, err := b.ReadFrom(gotReq.Body)
-			require.NoError(t, err)
-			assert.Contains(t, b.String(), `{"agent_metadata":{"version":"development","cluster_id":"test cluster name"}`)
-		})
-		cfg, cl, err := ValidateAndCombineConfig(discardLogs(),
-			withConfig(testutil.Undent(`
-				server: `+srv.URL+`
-				period: 1h
-				cluster_id: test cluster name
-			`)),
-			withCmdLineFlags("--disable-compression", "--venafi-connection", "venafi-components", "--install-namespace", "venafi"))
-		require.NoError(t, err)
-		testutil.VenConnStartWatching(t, cl)
-		testutil.TrustCA(t, cl, cert)
 		err = cl.PostDataReadingsWithOptions(nil, client.Options{ClusterName: cfg.ClusterID})
 		require.NoError(t, err)
 	})

--- a/pkg/client/client_venconn.go
+++ b/pkg/client/client_venconn.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/x509"
 	"encoding/base64"
@@ -33,8 +32,6 @@ type VenConnClient struct {
 	venConnName   string // Name of the VenafiConnection resource to use.
 	venConnNS     string // Namespace of the VenafiConnection resource to use.
 
-	disableCompression bool
-
 	// Used to make HTTP requests to Venafi Cloud. This field is public for
 	// testing purposes so that we can configure trusted CAs; there should be a
 	// way to do that without messing with the client directly (e.g., a flag to
@@ -54,7 +51,7 @@ type VenConnClient struct {
 // empty. `venConnName` and `venConnNS` must not be empty either. The passed
 // `restcfg` is not mutated. `trustedCAs` is only used for connecting to Venafi
 // Cloud and Vault and can be left nil.
-func NewVenConnClient(restcfg *rest.Config, agentMetadata *api.AgentMetadata, installNS, venConnName, venConnNS string, trustedCAs *x509.CertPool, disableCompression bool) (*VenConnClient, error) {
+func NewVenConnClient(restcfg *rest.Config, agentMetadata *api.AgentMetadata, installNS, venConnName, venConnNS string, trustedCAs *x509.CertPool) (*VenConnClient, error) {
 	if installNS == "" {
 		return nil, errors.New("programmer mistake: installNS must be provided")
 	}
@@ -109,13 +106,12 @@ func NewVenConnClient(restcfg *rest.Config, agentMetadata *api.AgentMetadata, in
 	}
 
 	return &VenConnClient{
-		agentMetadata:      agentMetadata,
-		connHandler:        handler,
-		installNS:          installNS,
-		venConnName:        venConnName,
-		venConnNS:          venConnNS,
-		Client:             vcpClient,
-		disableCompression: disableCompression,
+		agentMetadata: agentMetadata,
+		connHandler:   handler,
+		installNS:     installNS,
+		venConnName:   venConnName,
+		venConnNS:     venConnNS,
+		Client:        vcpClient,
 	}, nil
 }
 
@@ -156,21 +152,10 @@ func (c *VenConnClient) PostDataReadingsWithOptions(readings []*api.DataReading,
 	}
 
 	encodedBody := &bytes.Buffer{}
-	if c.disableCompression {
-		err = json.NewEncoder(encodedBody).Encode(payload)
-		if err != nil {
-			return err
-		}
-	} else {
-		gz := gzip.NewWriter(encodedBody)
-		err = json.NewEncoder(gz).Encode(payload)
-		if err != nil {
-			return err
-		}
-		err := gz.Close()
-		if err != nil {
-			return err
-		}
+
+	err = json.NewEncoder(encodedBody).Encode(payload)
+	if err != nil {
+		return err
 	}
 
 	// The path parameter "no" is a dummy parameter to make the Venafi Cloud
@@ -181,18 +166,6 @@ func (c *VenConnClient) PostDataReadingsWithOptions(readings []*api.DataReading,
 		return err
 	}
 
-	// We have noticed that NGINX, which is Venafi Control Plane's API gateway,
-	// has a limit on the request body size we can send (client_max_body_size).
-	// On large clusters, the agent may exceed this limit, triggering the error
-	// "413 Request Entity Too Large". Although this limit has been raised to
-	// 1GB, NGINX still buffers the requests that the agent sends because
-	// proxy_request_buffering isn't set to off. To reduce the strain on NGINX'
-	// memory and disk, to avoid further 413s, and to avoid reaching the maximum
-	// request body size of customer's proxies, we have decided to enable GZIP
-	// compression. Ref: https://venafi.atlassian.net/browse/VC-36434.
-	if !c.disableCompression {
-		req.Header.Set("Content-Encoding", "gzip")
-	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", fmt.Sprintf("venafi-kubernetes-agent/%s", version.PreflightVersion))
 

--- a/pkg/client/client_venconn_test.go
+++ b/pkg/client/client_venconn_test.go
@@ -233,7 +233,6 @@ func run_TestVenConnClient_PostDataReadingsWithOptions(restcfg *rest.Config, kcl
 			// Let's make sure we didn't forget to add the arbitrary "/no"
 			// (uploader_id) path segment to /v1/tlspk/upload/clusterdata.
 			assert.Equal(t, "/v1/tlspk/upload/clusterdata/no", r.URL.Path)
-			assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
 		})
 
 		certPool := x509.NewCertPool()
@@ -247,7 +246,6 @@ func run_TestVenConnClient_PostDataReadingsWithOptions(restcfg *rest.Config, kcl
 			"venafi-components",    // Name of the VenafiConnection.
 			testNameToNamespace(t), // Namespace of the VenafiConnection.
 			certPool,
-			false, // disableCompression
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
Ref: [VC-37264](https://venafi.atlassian.net/browse/VC-37264 "Disable agent's compression")

## Why?

On Nov 21, 2024, the Production Engineering team found that the test pipeline was failing due to venctl 1.15.3. They rolled back to venctl 1.15.2, which made the pipeline work again.

After investigating, we found that the Agent's compression feature broke the Agent. The Agent sends its upload request using `Content-Encoding: gzip`, but the server doesn't process this header and doesn't decompress the body. It copies the contents of the request's body to a bucket without checking its validity. When the backend asynchronously tries to process the contents of the upload, it fails with the error:

```
json: invalid character \u001f as token
```

## Solution

After some consideration, we decided to remove entirely the compression logic that was added in https://github.com/jetstack/jetstack-secure/pull/594. The `--disable-compression` flag **will no longer do anything**, and a log line will be printed when using the flag:

```
INFO The flag --disable-compression has been deprecated an no longer has any effect.
```

Previously, we wanted to simply switch the default value of the `--disable-compression` flag from `true` to `false`; we found the new logic clunky due to the fact that users can set `--disable-compression=false`, so we voted against it. We had also considered adding the flag `--disable-compression` to the Helm chart but realized that it would impact users that don't use the Venafi Connection mode nor the Key Pair Service Account mode.

## Manual test

For this test, I've used the tenant https://ven-tlspk.venafi.cloud/. To access the API key, use the user `system.admin@tlspk.qa.venafi.io` and the password is visible in the page [Production Accounts](https://venafi.atlassian.net/wiki/spaces/CT/pages/2115404149) (private to Venafi). Then go to the settings and find the API key, and set it in the env var `APIKEY`.

The tenant https://ven-tlspk.venafi.cloud/ doesn't have the right tier to pull images, so I use an API key from the tenant https://glow-in-the-dark.venafi.cloud/, that's why I set the env var `APIKEY_GLOW_IN_THE_DARK`. Ask Atanas to get access to the tenant https://glow-in-the-dark.venafi.cloud/.

```sh
export APIKEY=...
export APIKEY_GLOW_IN_THE_DARK=...
```

Then:

```sh
export \
 OCI_BASE=ttl.sh/maelvls \
 VEN_API_KEY=$APIKEY \
 VEN_API_KEY_PULL=$APIKEY_GLOW_IN_THE_DARK \
 VEN_API_HOST=api.venafi.cloud \
 VEN_VCP_REGION=us \
 VEN_ZONE='tlspk-bench\Default' \
 CLOUDSDK_CORE_PROJECT=jetstack-mael-valais \
 CLOUDSDK_COMPUTE_ZONE=europe-west1-b \
 CLUSTER_NAME=test-secretless
```

Then, create three files: `get.sh`, `create.sh`, and `rm.sh`:

```bash
#!/bin/bash
# get.sh

set -o nounset -o errexit -o pipefail

if [ $# -ne 1 ]; then
    echo "Usage: $0 <common-name>"
    exit 1
fi
commonname=$1

curl -sS --fail-with-body -X POST -H "tppl-api-key: $APIKEY" "https://api.venafi.cloud/outagedetection/v1/certificatesearch?excludeSupersededInstances=true&ownershipTree=true" -H "Content-Type: application/json" \
    -d @- <<EOF | jq
{
  "expression": {
    "field": "subjectCN",
    "operator": "MATCH",
    "value": $(jq -R <<<"$commonname")
  },
  "ordering": {
    "orders": [
      { "direction": "DESC", "field": "certificatInstanceModificationDate" }
    ]
  },
  "paging": { "pageNumber": 0, "pageSize": 10 }
}
EOF
```

```bash
#!/bin/bash
# create.sh

set -o nounset -o errexit -o pipefail

if [ $# -ne 1 ]; then
  echo "Usage: $0 <common-name>"
  exit 1
fi

commonname=$1

openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=$commonname"
kubectl create secret tls "$commonname" --cert=/tmp/tls.crt --key=/tmp/tls.key -o yaml --dry-run=client | kubectl apply -f -
```

```bash
#!/bin/bash
# rm.sh

set -o nounset -o errexit -o pipefail

if [ $# -ne 1 ]; then
  echo "Usage: $0 <common-name>"
  exit 1
fi
commonname=$1

json=$(
  curl -sS --fail-with-body -X POST -H "tppl-api-key: $APIKEY" "https://api.venafi.cloud/outagedetection/v1/certificatesearch?excludeSupersededInstances=true&ownershipTree=true" -H "Content-Type: application/json" -d @- <<EOF
{
  "expression": {
    "field": "subjectCN",
    "operator": "MATCH",
    "value": $(jq -R <<<"$commonname")
  },
  "ordering": {
    "orders": [
      { "direction": "DESC", "field": "certificatInstanceModificationDate" }
    ]
  },
  "paging": { "pageNumber": 0, "pageSize": 10 }
}
EOF
)

curl https://api.venafi.cloud/outagedetection/v1/certificates/retirement \
  -sS --fail-with-body -X POST -H "tppl-api-key: $APIKEY" -H "Content-Type: application/json" -d @- <<EOF
{"certificateIds": [$(jq '.certificates[].id' <<<"$json")]}
EOF

curl https://api.venafi.cloud/outagedetection/v1/certificates/deletion \
  -sS --fail-with-body -X POST -H "tppl-api-key: $APIKEY" -H "Content-Type: application/json" -d @- <<EOF
{"certificateIds": [$(jq '.certificates[].id' <<<"$json")]}
EOF
```

Now, run the end-to-end test:

```
./hack/e2e/test.sh
```

Once it completes, run:

```bash
sh create.sh foobar1234
```

Then, check that the certificate is present in Venafi Control Plane:

```bash
sh get.sh foobar1234
```

You should get something like this:

```json
{
  "count": 1,
  "certificates": [
    {
      "id": "94dde4e0-a8e2-11ef-a111-3f5044185ce5",
      "companyId": "756db001-280e-11ee-84fb-991f3177e2d0",
      "managedCertificateId": "95a29470-a8e2-11ef-9ac6-8b82bce2245b",
      "fingerprint": "525473DDA4EF4711C2BDF3221EC4B2137CC96BDF",
      "certificateName": "foobar1234",
      "issuerCertificateIds": [],
      "certificateStatus": "ACTIVE",
      "modificationDate": "2024-11-22T15:00:59.820+00:00",
      "validityStart": "2024-11-22T15:00:24.000+00:00",
      "validityEnd": "2025-11-22T15:00:24.000+00:00",
      "selfSigned": true,
      "signatureAlgorithm": "SHA256_WITH_RSA_ENCRYPTION",
      "signatureHashAlgorithm": "SHA256",
      "encryptionType": "RSA",
      "keyStrength": 2048,
      "subjectKeyIdentifierHash": "67226B08E29BBFD0F78899BDE975503D1E3E57DB",
      "authorityKeyIdentifierHash": "67226B08E29BBFD0F78899BDE975503D1E3E57DB",
      "serialNumber": "3B4BDC4E4255C26A1FE6E5ED0A0E7910B6CA3598",
      "subjectDN": "cn=foobar1234",
      "subjectCN": [
        "foobar1234"
      ],
      "subjectAlternativeNamesByType": {
        "otherName": [],
        "rfc822Name": [],
        "dNSName": [],
        "x400Address": [],
        "directoryName": [],
        "ediPartyName": [],
        "uniformResourceIdentifier": [],
        "iPAddress": [],
        "registeredID": []
      },
      "issuerDN": "cn=foobar1234",
      "issuerCN": [
        "foobar1234"
      ],
      "ocspNoCheck": false,
      "versionType": "CURRENT",
      "totalInstanceCount": 1,
      "totalActiveInstanceCount": 0,
      "instances": [],
      "ownership": {}
    }
  ]
}
```

## What was happening before?

Before this change, with v1.3.0, Venafi Kubernetes Agent used to not report secrets at all. It was successfully pushing, but the backend silently failed to process it.

```console
$ mine/create.sh s1234
.+++++++++++++++++++++++++++++++++++++++*.........+..+......+.+.....+.+........+....+........+++++++++++++++++++++++++++++++++++++++*...+..+...+............+.......+......+..+............+.+.........+.........++++++
......+...+++++++++++++++++++++++++++++++++++++++*.+.+.....+......+...+.......+............+..+......+....+++++++++++++++++++++++++++++++++++++++*.....+......+..+.......+..+.........+.+........+.+............+...++++++
-----
secret/s1234 created
```

```
$ mine/get.sh s1234
{
  "count": 0,
  "certificates": []
}
```

[VC-37264]: https://venafi.atlassian.net/browse/VC-37264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ