### PR TITLE
[VC-36032] Set User-Agent header containing the agent version in all HTTP requests

### DIFF
--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -178,7 +178,7 @@ func Test_ValidateAndCombineConfig(t *testing.T) {
 
 		// The log line printed by pflag is not captured by the log recorder.
 		assert.Equal(t, testutil.Undent(`
-			INFO Using the Jetstack Secure OAuth auth mode since --credentials-file was specified without --venafi-cloud.
+			INFO Authentication mode mode="Jetstack Secure OAuth" reason="--credentials-file was specified without --venafi-cloud"
 			INFO Using period from config period="1h0m0s"
 		`), b.String())
 	})

--- a/pkg/client/client_api_token.go
+++ b/pkg/client/client_api_token.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/version"
 	"k8s.io/client-go/transport"
 )
 
@@ -90,6 +91,7 @@ func (c *APITokenClient) Post(ctx context.Context, path string, body io.Reader) 
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiToken))
+	req.Header.Set("User-Agent", fmt.Sprintf("venafi-kubernetes-agent/%s", version.PreflightVersion))
 
 	return c.client.Do(req)
 }

--- a/pkg/client/client_oauth.go
+++ b/pkg/client/client_oauth.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/transport"
 
 	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/version"
 )
 
 type (
@@ -151,6 +152,7 @@ func (c *OAuthClient) Post(ctx context.Context, path string, body io.Reader) (*h
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("venafi-kubernetes-agent/%s", version.PreflightVersion))
 
 	if len(token.bearer) > 0 {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.bearer))
@@ -188,6 +190,7 @@ func (c *OAuthClient) renewAccessToken(ctx context.Context) error {
 		return errors.WithStack(err)
 	}
 	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", fmt.Sprintf("venafi-kubernetes-agent/%s", version.PreflightVersion))
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/client/client_venafi_cloud.go
+++ b/pkg/client/client_venafi_cloud.go
@@ -265,7 +265,7 @@ func (c *VenafiCloudClient) Post(ctx context.Context, path string, body io.Reade
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fullURL(c.baseURL, path), body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL(c.baseURL, path), body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client_venafi_cloud.go
+++ b/pkg/client/client_venafi_cloud.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/transport"
 
 	"github.com/jetstack/preflight/api"
+	"github.com/jetstack/preflight/pkg/version"
 )
 
 type (
@@ -272,6 +273,7 @@ func (c *VenafiCloudClient) Post(ctx context.Context, path string, body io.Reade
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("venafi-kubernetes-agent/%s", version.PreflightVersion))
 
 	if len(token.accessToken) > 0 {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.accessToken))
@@ -314,6 +316,7 @@ func (c *VenafiCloudClient) updateAccessToken(ctx context.Context) error {
 
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Add("Content-Length", strconv.Itoa(len(encoded)))
+	request.Header.Set("User-Agent", fmt.Sprintf("venafi-kubernetes-agent/%s", version.PreflightVersion))
 
 	now := time.Now()
 	accessToken := accessTokenInformation{}


### PR DESCRIPTION
In [VC-36032](https://venafi.atlassian.net/browse/VC-36032) we aim to provide:
> Enhanced troubleshooting through improved logging

By adding user-agent headers to *all* HTTP requests, it will allow the Venafi platform team to know which version of the agent is making requests to the resource and auth APIs, by analysing the request headers among the server logs.

I tried writing tests for this, but the it would have required some significant refactoring of the client code,
for example there's no easy way to intercept the  Auth0 client request made by the Jetstack-Secure client in client_oauth.go.
That's a bit of a lame excuse, but I would like to propose that we refactor the Venafi client code in a followup PR and at the same time add tests which verify that all the flavours of Venafi client do include user agent headers.

[VC-36032]: https://venafi.atlassian.net/browse/VC-36032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ