### PR TITLE
README: badge wasn't showing the latest job run from master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: tests
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request: {}
 jobs:
   verify:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/jetstack/jetstack-secure/actions/workflows/tests.yaml/badge.svg)](https://github.com/jetstack/jetstack-secure/actions/workflows/tests.yaml)
+[![tests](https://github.com/jetstack/jetstack-secure/actions/workflows/tests.yaml/badge.svg?branch=master&event=push)](https://github.com/jetstack/jetstack-secure/actions/workflows/tests.yaml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/jetstack/jetstack-secure.svg)](https://pkg.go.dev/github.com/jetstack/jetstack-secure)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jetstack/jetstack-secure)](https://goreportcard.com/report/github.com/jetstack/jetstack-secure)
 

--- a/README.md
+++ b/README.md
@@ -102,25 +102,34 @@ The release process is semi-automated.
 > - Create a draft GitHub release,
 > - Upload the Helm chart tarball to the GitHub release.
 
-1. Create a tag for the new release:
+1. Open the [tests GitHub Actions workflow][tests-workflow]
+   and verify that it succeeds on the master branch.
+2. Run govulncheck:
+   ```bash
+   go install golang.org/x/vuln/cmd/govulncheck@latest
+   govulncheck -v ./...
+   ```
+3. Create a tag for the new release:
    ```sh
    export VERSION=v1.1.0
    git tag --annotate --message="Release ${VERSION}" "${VERSION}"
    git push origin "${VERSION}"
    ```
-2. Wait until the GitHub Actions finishes.
-3. Navigate to the GitHub Releases page and select the draft release to edit.
+4. Wait until the GitHub Actions finishes.
+5. Navigate to the GitHub Releases page and select the draft release to edit.
    1. Click on “Generate release notes” to automatically compile the changelog.
    2. Review and refine the generated notes to ensure they’re clear and useful
       for end users.
    3. Remove any irrelevant entries, such as “update deps,” “update CI,” “update
       docs,” or similar internal changes that do not impact user functionality.
-4. Publish the release.
-5. Inform the `#venctl` channel that a new version of Venafi Kubernetes Agent has been
+6. Publish the release.
+7. Inform the `#venctl` channel that a new version of Venafi Kubernetes Agent has been
    released. Make sure to share any breaking change that may affect `venctl connect`
    or `venctl generate`.
-7. Inform Michael McLoughlin of the new release so he can update the
+8. Inform Michael McLoughlin of the new release so he can update the
    documentation at <https://docs.venafi.cloud/>.
+
+[tests-workflow]: https://github.com/jetstack/jetstack-secure/actions/workflows/tests.yaml?query=branch%3Amaster
 
 > [!NOTE]
 >


### PR DESCRIPTION
The badge wasn't showing the latest job run from master. It was green because the workflow was green due to the pull requests. 

Before:
<img width="110" alt="Screenshot 2024-12-02 at 10 59 51" src="https://github.com/user-attachments/assets/b3f6f429-1058-4757-a7a3-9382288a6ff2">

After:
<img width="120" alt="Screenshot 2024-12-02 at 10 59 53" src="https://github.com/user-attachments/assets/44080159-2c1b-46a5-b51d-ac708d828807">

The badge is now grayed out becuase the "tests" workflow doesn't currently run on the master branch due to probable copy-paste issue (it was set to trigger on the main branch, but this project doesn't have a main branch).

Fixes #632 