### PR TITLE
Make `venafiConnection` a root-level Helm option

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/README.md
+++ b/deploy/charts/venafi-kubernetes-agent/README.md
@@ -476,6 +476,13 @@ Cannot be used if `maxUnavailable` is set.
 Configure the maximum unavailable pods for disruptions. Can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).  
 Cannot be used if `minAvailable` is set.
 
+#### **venafiConnection.include** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+When set to false, the rendered output does not contain the. VenafiConnection CRDs and RBAC. This is useful for when the. Venafi Connection resources are already installed separately.
 ### CRDs
 
 
@@ -494,12 +501,5 @@ The 'x-kubernetes-validations' annotation is not supported in Kubernetes 1.22 an
 > ```
 
 This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled.
-#### **crds.venafiConnection.include** ~ `bool`
-> Default value:
-> ```yaml
-> false
-> ```
-
-When set to false, the rendered output does not contain the. VenafiConnection CRDs and RBAC. This is useful for when the. Venafi Connection resources are already installed separately.
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/venafi-kubernetes-agent/crd_bases/crd.header-without-validations.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/crd_bases/crd.header-without-validations.yaml
@@ -1,5 +1,5 @@
 {{/* DO NOT EDIT. Use 'make generate-crds-venconn' to regenerate. */}}
-{{- if .Values.crds.venafiConnection.include }}
+{{- if .Values.venafiConnection.include }}
 {{- if (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -12,4 +12,4 @@ metadata:
     helm.sh/resource-policy: keep
   {{- end }}
   labels:
-  {{- include "venafi-connection.labels" . | nindent 4 }}
+  {{- include "venafi-connection.labels" $ | nindent 4 }}

--- a/deploy/charts/venafi-kubernetes-agent/crd_bases/crd.header.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/crd_bases/crd.header.yaml
@@ -1,5 +1,5 @@
 {{/* DO NOT EDIT. Use 'make generate-crds-venconn' to regenerate. */}}
-{{- if .Values.crds.venafiConnection.include }}
+{{- if .Values.venafiConnection.include }}
 {{- if not (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -12,4 +12,4 @@ metadata:
     helm.sh/resource-policy: keep
   {{- end }}
   labels:
-  {{- include "venafi-connection.labels" . | nindent 4 }}
+  {{- include "venafi-connection.labels" $ | nindent 4 }}

--- a/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.without-validations.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.without-validations.yaml
@@ -1,5 +1,5 @@
 {{/* DO NOT EDIT. Use 'make generate-crds-venconn' to regenerate. */}}
-{{- if .Values.crds.venafiConnection.include }}
+{{- if .Values.venafiConnection.include }}
 {{- if (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -12,7 +12,7 @@ metadata:
     helm.sh/resource-policy: keep
   {{- end }}
   labels:
-  {{- include "venafi-connection.labels" . | nindent 4 }}
+  {{- include "venafi-connection.labels" $ | nindent 4 }}
 spec:
   group: jetstack.io
   names:

--- a/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-crd.yaml
@@ -1,5 +1,5 @@
 {{/* DO NOT EDIT. Use 'make generate-crds-venconn' to regenerate. */}}
-{{- if .Values.crds.venafiConnection.include }}
+{{- if .Values.venafiConnection.include }}
 {{- if not (or (semverCompare "<1.25" .Capabilities.KubeVersion.GitVersion) .Values.crds.forceRemoveValidationAnnotations) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -12,7 +12,7 @@ metadata:
     helm.sh/resource-policy: keep
   {{- end }}
   labels:
-  {{- include "venafi-connection.labels" . | nindent 4 }}
+  {{- include "venafi-connection.labels" $ | nindent 4 }}
 spec:
   group: jetstack.io
   names:

--- a/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-rbac.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/venafi-connection-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crds.venafiConnection.include }}
+{{- if .Values.venafiConnection.include }}
 # The 'venafi-connection' service account is used by multiple
 # controllers. When configuring which resources a VenafiConnection
 # can access, the RBAC rules you create manually must point to this SA.

--- a/deploy/charts/venafi-kubernetes-agent/values.schema.json
+++ b/deploy/charts/venafi-kubernetes-agent/values.schema.json
@@ -75,6 +75,9 @@
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
         },
+        "venafiConnection": {
+          "$ref": "#/$defs/helm-values.venafiConnection"
+        },
         "volumeMounts": {
           "$ref": "#/$defs/helm-values.volumeMounts"
         },
@@ -275,9 +278,6 @@
         },
         "keep": {
           "$ref": "#/$defs/helm-values.crds.keep"
-        },
-        "venafiConnection": {
-          "$ref": "#/$defs/helm-values.crds.venafiConnection"
         }
       },
       "type": "object"
@@ -290,20 +290,6 @@
     "helm-values.crds.keep": {
       "default": false,
       "description": "This option makes it so that the \"helm.sh/resource-policy\": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled.",
-      "type": "boolean"
-    },
-    "helm-values.crds.venafiConnection": {
-      "additionalProperties": false,
-      "properties": {
-        "include": {
-          "$ref": "#/$defs/helm-values.crds.venafiConnection.include"
-        }
-      },
-      "type": "object"
-    },
-    "helm-values.crds.venafiConnection.include": {
-      "default": false,
-      "description": "When set to false, the rendered output does not contain the. VenafiConnection CRDs and RBAC. This is useful for when the. Venafi Connection resources are already installed separately.",
       "type": "boolean"
     },
     "helm-values.extraArgs": {
@@ -637,6 +623,20 @@
       "description": "Embed YAML for toleration settings, see\nhttps://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
       "items": {},
       "type": "array"
+    },
+    "helm-values.venafiConnection": {
+      "additionalProperties": false,
+      "properties": {
+        "include": {
+          "$ref": "#/$defs/helm-values.venafiConnection.include"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.venafiConnection.include": {
+      "default": false,
+      "description": "When set to false, the rendered output does not contain the. VenafiConnection CRDs and RBAC. This is useful for when the. Venafi Connection resources are already installed separately.",
+      "type": "boolean"
     },
     "helm-values.volumeMounts": {
       "default": [],

--- a/deploy/charts/venafi-kubernetes-agent/values.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/values.yaml
@@ -285,6 +285,13 @@ podDisruptionBudget:
   # +docs:property
   # maxUnavailable: 1
 
+# Optionally include the VenafiConnection CRDs
+venafiConnection:
+  # When set to false, the rendered output does not contain the
+  # VenafiConnection CRDs and RBAC. This is useful for when the
+  # Venafi Connection resources are already installed separately.
+  include: false
+
 # +docs:section=CRDs
 # The CRDs installed by this chart are annotated with "helm.sh/resource-policy: keep", this
 # prevents them from being accidentally removed by Helm when this chart is deleted. After
@@ -301,10 +308,3 @@ crds:
   # annotation is added to the CRD. This will prevent Helm from uninstalling
   # the CRD when the Helm release is uninstalled.
   keep: false
-
-  # Optionally include the VenafiConnection CRDs
-  venafiConnection:
-    # When set to false, the rendered output does not contain the
-    # VenafiConnection CRDs and RBAC. This is useful for when the
-    # Venafi Connection resources are already installed separately.
-    include: false


### PR DESCRIPTION
Move the `venafiConnection` option out of the `crds` sub-object. This matches the config structure we have in other projects.
Next, in a future PR, we can add the `serviceAccountNamespace` option to the `venafiConnection` object.

This is a breaking change, we might want to still allow the old field to be used, but I think it is ok to change the location since users will get an error when they try to use the old field thanks to the json validation.