### PR TITLE
VC-39644 Collect info for the venafiConnection and more issuers

### DIFF
--- a/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/configmap.yaml
@@ -202,6 +202,13 @@ data:
           group: route.openshift.io
           resource: routes
     - kind: "k8s-dynamic"
+      name: "k8s/venaficonnections"
+      config:
+        resource-type:
+          group: jetstack.io
+          version: v1alpha1
+          resource: venaficonnections
+    - kind: "k8s-dynamic"
       name: "k8s/venaficlusterissuers"
       config:
         resource-type:
@@ -222,4 +229,60 @@ data:
           group: firefly.venafi.com
           version: v1
           resource: issuers
+    - kind: "k8s-dynamic"
+      name: "k8s/stepissuers"
+      config:
+        resource-type:
+          group: certmanager.step.sm
+          version: v1beta1
+          resource: stepissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/stepclusterissuers"
+      config:
+        resource-type:
+          group: certmanager.step.sm
+          version: v1beta1
+          resource: stepclusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/originissuers"
+      config:
+        resource-type:
+          group: cert-manager.k8s.cloudflare.com
+          version: v1
+          resource: originissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/clusteroriginissuers"
+      config:
+        resource-type:
+          group: cert-manager.k8s.cloudflare.com
+          version: v1
+          resource: clusteroriginissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/freeipaissuers"
+      config:
+        resource-type:
+          group: certmanager.freeipa.org
+          version: v1beta1
+          resource: issuers
+    - kind: "k8s-dynamic"
+      name: "k8s/freeipaclusterissuers"
+      config:
+        resource-type:
+          group: certmanager.freeipa.org
+          version: v1beta1
+          resource: clusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/ejbcaissuers"
+      config:
+        resource-type:
+          group: ejbca-issuer.keyfactor.com
+          version: v1alpha1
+          resource: issuers
+    - kind: "k8s-dynamic"
+      name: "k8s/ejbcaclusterissuers"
+      config:
+        resource-type:
+          group: ejbca-issuer.keyfactor.com
+          version: v1alpha1
+          resource: clusterissuers
 {{- end }}

--- a/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/rbac.yaml
@@ -264,6 +264,33 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-venafi-connection-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["jetstack.io"]
+    resources:
+      - venaficonnections
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-venafi-connection-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-venafi-connection-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: {{ include "venafi-kubernetes-agent.fullname" . }}-venafi-enhanced-reader
   labels:
     {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
@@ -315,3 +342,116 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-step-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["certmanager.step.sm"]
+    resources:
+      - stepissuers
+      - stepclusterissuers
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-step-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-step-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-cloudflare-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["cert-manager.k8s.cloudflare.com"]
+    resources:
+      - originissuers
+      - clusteroriginissuers
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-cloudflare-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-cloudflare-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-freeipa-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["certmanager.freeipa.org"]
+    resources:
+      - issuers
+      - clusterissuers
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-freeipa-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-freeipa-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-keyfactor-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["ejbca-issuer.keyfactor.com"]
+    resources:
+      - issuers
+      - clusterissuers
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-keyfactor-reader
+  labels:
+    {{- include "venafi-kubernetes-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "venafi-kubernetes-agent.fullname" . }}-keyfactor-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "venafi-kubernetes-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+


### PR DESCRIPTION
This PR updates the Kubernetes agent by extending its resource collection capabilities. The newly supported resources include:

* Venafi Connection
* Smallstep Issuer
* Cloudflare Origin CA
* FreeIPA Issuer
* EJBCA Issuer