### PR TITLE
make upgrade-klone

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 

--- a/.github/workflows/make-self-upgrade.yaml
+++ b/.github/workflows/make-self-upgrade.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 

--- a/klone.yaml
+++ b/klone.yaml
@@ -10,55 +10,55 @@ targets:
     - folder_name: generate-verify
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/generate-verify
     - folder_name: go
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/go
     - folder_name: helm
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/helm
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/help
     - folder_name: kind
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/kind
     - folder_name: klone
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/klone
     - folder_name: licenses
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/licenses
     - folder_name: oci-build
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/oci-build
     - folder_name: oci-publish
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/oci-publish
     - folder_name: repository-base
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/repository-base
     - folder_name: tools
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 64ae59dc5eefce752ff785f648ac8a8ed0222cbd
+      repo_hash: 5c3266f17637fbd1d4af1191b34674991e2160ab
       repo_path: modules/tools

--- a/make/_shared/go/base/.github/workflows/govulncheck.yaml
+++ b/make/_shared/go/base/.github/workflows/govulncheck.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 

--- a/make/_shared/oci-build/00_mod.mk
+++ b/make/_shared/oci-build/00_mod.mk
@@ -16,11 +16,11 @@ oci_platforms ?= linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
 
 # Use distroless as minimal base image to package the manager binary
 # To get latest SHA run "crane digest quay.io/jetstack/base-static:latest"
-base_image_static := quay.io/jetstack/base-static@sha256:16a5a64b918592f5c38fa73721a87f8585a3a501d261087e7b953f8b59279cd0
+base_image_static := quay.io/jetstack/base-static@sha256:01d887b98d90226dbaeb32b9cab0dbede410a652fa16829c6fd2f94df55d7757
 
 # Use custom apko-built image as minimal base image to package the manager binary
 # To get latest SHA run "crane digest quay.io/jetstack/base-static-csi:latest"
-base_image_csi-static := quay.io/jetstack/base-static-csi@sha256:fb97fc098aabdfb5b9b01475d3531b688a9c2219f4bbc143816d3e47a267be6d
+base_image_csi-static := quay.io/jetstack/base-static-csi@sha256:35531ca8c25f441a15b9ae211aaa2a9978334c45dd2a9c130525aa73c8bdf5af
 
 # Utility functions
 fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))

--- a/make/_shared/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/make/_shared/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -172,7 +172,7 @@ ADDITIONAL_TOOLS ?=
 tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
-VENDORED_GO_VERSION := 1.24.2
+VENDORED_GO_VERSION := 1.24.3
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -395,10 +395,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad
-go_linux_arm64_SHA256SUM=756274ea4b68fa5535eb9fe2559889287d725a8da63c6aae4d5f23778c229f4b
-go_darwin_amd64_SHA256SUM=238d9c065d09ff6af229d2e3b8b5e85e688318d69f4006fb85a96e41c216ea83
-go_darwin_arm64_SHA256SUM=b70f8b3c5b4ccb0ad4ffa5ee91cd38075df20fdbd953a1daedd47f50fbcff47a
+go_linux_amd64_SHA256SUM=3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8
+go_linux_arm64_SHA256SUM=a463cb59382bd7ae7d8f4c68846e73c4d589f223c589ac76871b66811ded7836
+go_darwin_amd64_SHA256SUM=13e6fe3fcf65689d77d40e633de1e31c6febbdbcb846eb05fc2434ed2213e92b
+go_darwin_arm64_SHA256SUM=64a3fa22142f627e78fac3018ce3d4aeace68b743eff0afda8aae0411df5e4fb
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
I ran `make upgrade-klone` because I thought the latest tools module might include `venctl`, but it didn't.
Not sure why the automatic makefile-modules updates aren't working in this repo. 
