### PR TITLE
chore: changes to jetstack-agent chart to use new Agent image

### DIFF
--- a/deploy/charts/jetstack-agent/templates/deployment.yaml
+++ b/deploy/charts/jetstack-agent/templates/deployment.yaml
@@ -33,14 +33,30 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if  eq .Values.authentication.type "token" }}
           env:
-            - name: API_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "agent-credentials" .Values.authentication.secretName }}
-                  key: {{ default "apitoken" .Values.authentication.secretKey }}
+          {{- if  eq .Values.authentication.type "token" }}
+          - name: API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ default "agent-credentials" .Values.authentication.secretName }}
+                key: {{ default "apitoken" .Values.authentication.secretKey }}
           {{- end }}
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: POD_NODE
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           {{- if not (empty .Values.command) }}
           command:
           {{- range .Values.command }}

--- a/deploy/charts/jetstack-agent/values.yaml
+++ b/deploy/charts/jetstack-agent/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 
 image:
   # -- Default to Open Source image repository
-  repository: quay.io/jetstack/preflight
+  repository: "registry.venafi.cloud/venafi-agent/venafi-agent"
   # -- Defaults to only pull if not already present
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion
-  tag: "v0.1.43"
+  tag: "v1.6.0"
 
 # -- Specify image pull credentials if using a prviate registry
 imagePullSecrets: []

--- a/hack/install_local_jetstack_secure_chart.sh
+++ b/hack/install_local_jetstack_secure_chart.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# This script is provided to quickly install the Jetstack Secure Helm chart from the local checkout
+# into a Kind cluster, for testing changes to the legacy chart with Jetstack Secure.
+#
+# This script should be invoked from the root of the repository, e.g.:
+# ./hack/install_local_jetstack_secure_chart.sh
+
+TLSPK_ORG="${TLSPK_ORG:-jetstack}"
+TLSPK_CLUSTER_NAME="jss_test_$(date +"%Y%m%d_%H%M")"
+
+helm install cert-manager oci://quay.io/jetstack/charts/cert-manager:v1.18.2 \
+	--set crds.enabled=true \
+	--namespace cert-manager \
+	--create-namespace \
+	--set 'extraArgs={--dns01-recursive-nameservers-only,--dns01-recursive-nameservers=https://1.1.1.1/dns-query}'
+
+kubectl create namespace jetstack-secure || :
+
+# Get credentials from: https://platform.jetstack.io/org/jetstack/manage/service_accounts
+# Save them as JSON a file named credentials.json
+kubectl create secret generic agent-credentials --namespace jetstack-secure --from-file=credentials.json || :
+
+helm upgrade --install --create-namespace -n jetstack-secure jetstack-agent \
+    ./deploy/charts/jetstack-agent	\
+	--set config.organisation="${TLSPK_ORG}" \
+	--set config.cluster="${TLSPK_CLUSTER_NAME}"


### PR DESCRIPTION
The old preflight image is not maintained or built any more. This PR changes the old chart on the legacy-jetstack-secure branch to use the new Agent image by default.

The env var changes for POD_NAMESPACE and POD_NAME are required to prevent errors due to changes in the Agent image.

POD_UID and POD_NODE are included because it seems harmless.

Still required: this will prints errors since the new agent image will look for OpenShift routes:

> I0721 13:16:41.243219       1 dynamic.go:283] "datagatherer informer has failed and is backing off" groupVersionResource="route.openshift.io/v1, Resource=routes" reason="failed to list route.openshift.io/v1, Resource=routes: routes.route.openshift.io is forbidden: User \"system:serviceaccount:jetstack-secure:jetstack-agent\" cannot list resource \"routes\" in API group \"route.openshift.io\" at the cluster scope"

We might need to expand the permissions in the legacy chart, or else prevent this check being made by the agent.