### PR TITLE
[VC-43753] Update the dataupload package to be compatible with the inventory API

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,8 +21,10 @@ var GoVersion string
 
 // UserAgent return a standard user agent for use with all HTTP requests. This is implemented in one place so
 // it's uniform across the Kubernetes Agent.
+//
+// TODO(wallrj): The prefix "Mozilla/5.0" is currently required by the CyberArk inventory API. Remove the prefix when CyberArk relax the API security settings.
 func UserAgent() string {
-	return fmt.Sprintf("venafi-kubernetes-agent/%s", PreflightVersion)
+	return fmt.Sprintf("Mozilla/5.0 venafi-kubernetes-agent/%s", PreflightVersion)
 }
 
 // SetUserAgent augments an http.Request with a standard user agent.


### PR DESCRIPTION
Closes: https://venafi.atlassian.net/browse/VC-43753

- This PR updates the `dataupload` package for compatibility with the CyberArk Discovery and Context Inventory API, which is now available for testing.
- You will find a link to the latest API design in the Jira issue.
- The changes have been E2E tested in the PoC branch in #678 
- We also need to modify structure of the uploaded data, but I'll do that in a followup PR.

## Testing

I added a (temporary) integration test to demonstrate the dataupload client working with the real API

```
$ go test ./pkg/internal/cyberark/dataupload/... -v -run Real -count 1
=== RUN   TestPostDataReadingsWithOptionsWithRealAPI
    identity.go:328: I0807 09:43:44.914749] made successful request to StartAuthentication source="Identity.doStartAuthentication" summary="NewPackage"
    identity.go:444: I0807 09:43:45.478020] successfully completed AdvanceAuthentication request to CyberArk Identity; login complete username="richard_wall@cyberark.cloud.420375"
--- PASS: TestPostDataReadingsWithOptionsWithRealAPI (2.80s)
PASS
ok      github.com/jetstack/preflight/pkg/internal/cyberark/dataupload  2.818s
```


Here's the sequence of API calls:
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/8d59bcbc-c3c5-44d8-940c-d8c5cb833453" />

Here's a response from the snapshot-links endpoint:
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/d87735f1-87e1-49b4-963b-4952919a25bd" />

Here's the PUT request to the AWS presigned URL:

<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/651f7f83-28d8-44e1-9d44-18a8096271a3" />


