### PR TITLE
[VC-43753] CyberArk Discovery and Context: Use sha3 checksum in snapshot-links API request

### DIFF
--- a/pkg/internal/cyberark/dataupload/dataupload.go
+++ b/pkg/internal/cyberark/dataupload/dataupload.go
@@ -3,7 +3,7 @@ package dataupload
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
+	"crypto/sha3"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -64,7 +64,7 @@ func (c *CyberArkClient) PostDataReadingsWithOptions(ctx context.Context, payloa
 	}
 
 	encodedBody := &bytes.Buffer{}
-	checksum := sha256.New()
+	checksum := sha3.New256()
 	if err := json.NewEncoder(io.MultiWriter(encodedBody, checksum)).Encode(payload); err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (c *CyberArkClient) retrievePresignedUploadURL(ctx context.Context, checksu
 
 	request := struct {
 		ClusterID    string `json:"cluster_id"`
-		Checksum     string `json:"checksum_sha256"`
+		Checksum     string `json:"checksum_sha3"`
 		AgentVersion string `json:"agent_version"`
 	}{
 		ClusterID:    opts.ClusterName,


### PR DESCRIPTION
The integration test was failing because the request body format for the snapshot-links API has been changed, to accept a sha3 checksum instead of a sha256 checksum. 
I've updated the dataupload client accordingly.

Part of: https://venafi.atlassian.net/browse/VC-43753

## Related PRs

1. 🟢  #686 
1. ⚪  #684 
1. ⚪  #687 

## Testing

Before:

```
$ go test -v ./pkg/internal/cyberark/dataupload/... -run Real
warning: both GOPATH and GOROOT are the same directory (/home/richard/go); see https://go.dev/wiki/InstallTroubleshooting
=== RUN   TestPostDataReadingsWithOptionsWithRealAPI
    identity.go:330: I0813 17:07:34.740886] made successful request to StartAuthentication source="Identity.doStartAuthentication" summary="NewPackage"
    identity.go:446: I0813 17:07:35.184892] successfully completed AdvanceAuthentication request to CyberArk Identity; login complete username="richard_wall@cyberark.cloud.420375"
    dataupload_test.go:178:
                Error Trace:    /home/richard/projects/jetstack/jetstack-secure/pkg/internal/cyberark/dataupload/dataupload_test.go:178
                Error:          Received unexpected error:
                                while retrieving snapshot upload URL: received response with status code 400: {"error": "Invalid request format"}
                Test:           TestPostDataReadingsWithOptionsWithRealAPI
--- FAIL: TestPostDataReadingsWithOptionsWithRealAPI (1.82s)
FAIL
FAIL    github.com/jetstack/preflight/pkg/internal/cyberark/dataupload  1.834s
FAIL
```

```
POST https://tlskp-test.inventory.integration-cyberark.cloud/api/ingestions/kubernetes/snapshot-links HTTP/2.0
content-type: application/json
authorization: Bearer <REDACTED>
user-agent: Mozilla/5.0 venafi-kubernetes-agent/development
content-length: 169
accept-encoding: gzip

{"cluster_id":"bb068932-c80d-460d-88df-34bc7f3f3297","checksum_sha256":"7174d744c44b8f5f2661614089f29a560e1174f5d976048c2ae8c3e30e2f4a80","agent_version":"development"}


HTTP/2.0 400
date: Wed, 13 Aug 2025 14:18:06 GMT
content-type: application/json
content-length: 35

{"error": "Invalid request format"}
```

After:

```
$ go test -v ./pkg/internal/cyberark/dataupload/... -run Real
warning: both GOPATH and GOROOT are the same directory (/home/richard/go); see https://go.dev/wiki/InstallTroubleshooting
=== RUN   TestPostDataReadingsWithOptionsWithRealAPI
    identity.go:330: I0813 17:10:16.846642] made successful request to StartAuthentication source="Identity.doStartAuthentication" summary="NewPackage"
    identity.go:446: I0813 17:10:17.448351] successfully completed AdvanceAuthentication request to CyberArk Identity; login complete username="richard_wall@cyberark.cloud.420375"
--- PASS: TestPostDataReadingsWithOptionsWithRealAPI (4.07s)
PASS
ok      github.com/jetstack/preflight/pkg/internal/cyberark/dataupload  4.086s
```

```
POST https://tlskp-test.inventory.integration-cyberark.cloud/api/ingestions/kubernetes/snapshot-links HTTP/2.0
user-agent: Mozilla/5.0 venafi-kubernetes-agent/development
content-type: application/json
authorization: Bearer <REDACTED>
content-length: 167
accept-encoding: gzip

{"cluster_id":"bb068932-c80d-460d-88df-34bc7f3f3297","checksum_sha3":"c2ddaf1817d267c17e390ca4931a446fca5252bad9096120414bff40d87604a0","agent_version":"development"}


HTTP/2.0 200
date: Wed, 13 Aug 2025 16:10:19 GMT
content-type: application/json
content-length: 1710

{"url": "<REDACTED>"}
```