### PR TITLE
[VC-43753] Collect creationTimestamp, deletionTimestamp and resourceVersion metadata for Secret and Route resources

### DIFF
--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -5,7 +5,10 @@ import (
 )
 
 // SecretSelectedFields is the list of fields sent from Secret objects to the
-// backend
+// backend.
+// The `data` is redacted, to prevent private keys or sensitive data being
+// collected. Only the following none-sensitive keys are retained: tls.crt,
+// ca.crt. These keys are assumed to always contain public TLS certificates.
 var SecretSelectedFields = []FieldPath{
 	{"kind"},
 	{"apiVersion"},
@@ -16,6 +19,9 @@ var SecretSelectedFields = []FieldPath{
 	{"metadata", "ownerReferences"},
 	{"metadata", "selfLink"},
 	{"metadata", "uid"},
+	{"metadata", "creationTimestamp"},
+	{"metadata", "deletionTimestamp"},
+	{"metadata", "resourceVersion"},
 
 	{"type"},
 	{"data", "tls.crt"},
@@ -23,7 +29,16 @@ var SecretSelectedFields = []FieldPath{
 }
 
 // RouteSelectedFields is the list of fields sent from OpenShift Route objects to the
-// backend
+// backend.
+// The Route resource is redacted because it may contain private keys for TLS.
+//
+// TODO(wallrj): Find out if the `.tls.key` field is the only one that may
+// contain sensitive data and if so, that field could be redacted instead
+// selecting everything else, for consistency with Ingress or any of the other
+// resources that are collected. Or alternatively add an comment to explain why
+// for Route, the set of fields is allow-listed while for Ingress, all fields
+// are collected.
+// https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/network_apis/route-route-openshift-io-v1#spec-tls-3
 var RouteSelectedFields = []FieldPath{
 	{"kind"},
 	{"apiVersion"},
@@ -33,6 +48,9 @@ var RouteSelectedFields = []FieldPath{
 	{"metadata", "ownerReferences"},
 	{"metadata", "selfLink"},
 	{"metadata", "uid"},
+	{"metadata", "creationTimestamp"},
+	{"metadata", "deletionTimestamp"},
+	{"metadata", "resourceVersion"},
 
 	{"spec", "host"},
 	{"spec", "to", "kind"},

--- a/pkg/datagatherer/k8s/fieldfilter_test.go
+++ b/pkg/datagatherer/k8s/fieldfilter_test.go
@@ -25,6 +25,13 @@ func TestSelect(t *testing.T) {
 				"labels": map[string]interface{}{
 					"foo": "bar",
 				},
+				"resourceVersion":   "fake-resource-version",
+				"creationTimestamp": "2025-08-15T00:00:01Z",
+				"deletionTimestamp": "2025-08-15T00:00:02Z",
+				// Examples of fields which are dropped
+				"deletionGracePeriodSeconds": 10,
+				"finalizers":                 []string{"example.com/fake-finalizer"},
+				"generation":                 11,
 			},
 			"type": "kubernetes.io/tls",
 			"data": map[string]interface{}{
@@ -47,6 +54,9 @@ func TestSelect(t *testing.T) {
 				"labels": map[string]interface{}{
 					"foo": "bar",
 				},
+				"resourceVersion":   "fake-resource-version",
+				"creationTimestamp": "2025-08-15T00:00:01Z",
+				"deletionTimestamp": "2025-08-15T00:00:02Z",
 			},
 			"type": "kubernetes.io/tls",
 			"data": map[string]interface{}{
@@ -68,6 +78,13 @@ func TestSelect(t *testing.T) {
 				"labels": map[string]interface{}{
 					"foo": "bar",
 				},
+				"resourceVersion":   "fake-resource-version",
+				"creationTimestamp": "2025-08-15T00:00:01Z",
+				"deletionTimestamp": "2025-08-15T00:00:02Z",
+				// Examples of fields which are dropped
+				"deletionGracePeriodSeconds": 10,
+				"finalizers":                 []string{"example.com/fake-finalizer"},
+				"generation":                 11,
 			},
 			"spec": map[string]interface{}{
 				"host": "www.example.com",
@@ -94,6 +111,9 @@ func TestSelect(t *testing.T) {
 					// "Select". "Redact" removes it.
 					"kubectl.kubernetes.io/last-applied-configuration": "secret",
 				},
+				"resourceVersion":   "fake-resource-version",
+				"creationTimestamp": "2025-08-15T00:00:01Z",
+				"deletionTimestamp": "2025-08-15T00:00:02Z",
 			},
 			"spec": map[string]interface{}{
 				"host": "www.example.com",


### PR DESCRIPTION
The CyberArk Discovery and Context API team requested the creationTimestamp and resourceVersion for Secret resources.
I assume the TLSPK backend does not need this metadata, but it seems harmless to add it.
I also added deletionTimestamp, because I expect the CyberArk API will eventually want that too.
And I added these new metadata fields to the Route handling, for consistency.

Secret and Route are the only two resources where the fields are allow-listed. 
All other resources are pushed to the backend in-full, including **all** the metadata fields.

I think it would be more consistent if we published the same metadata fields for all resources, and I've tried to express that in some new function comments. 

>  For all resources there is some special case filtering for sensitive labels and annotations, removal of superfluous managed-fields and removal of large `last-applied-configuration` annotations.

Part of: https://venafi.atlassian.net/browse/VC-43753


## Testing

You can see the extra fields that are collected as follows:

I collected two sample output files using code from master (before) and from this branch (after) and then diffed them

```bash
go run . agent \
  --install-namespace venafi \
  --api-token unused \
  --one-shot \
  --agent-config-file examples/one-shot-secret.yaml  \
  --output-path=before.json
```

```diff
$ diff -u <(jq -S < before.json ) <(jq -S < after.json)
--- /dev/fd/63  2025-08-19 16:37:14.249233168 +0100
+++ /dev/fd/62  2025-08-19 16:37:14.250233165 +0100
@@ -8,44 +8,7 @@
             "apiVersion": "v1",
             "kind": "Secret",
             "metadata": {
+              "creationTimestamp": "2025-08-15T13:11:55Z",
               "labels": {
                 "cert-manager.io/next-private-key": "true",
                 "controller.cert-manager.io/fao": "true"
@@ -62,6 +25,7 @@
                   "uid": "4f1f5a25-dfa8-40dd-bd97-4a652855ec31"
                 }
               ],
+              "resourceVersion": "959",
               "uid": "c629b2ed-409b-4ae1-938f-2e224a74031f"
             },
             "type": "Opaque"
@@ -79,20 +43,64 @@
               "annotations": {
                 "cert-manager.io/allow-direct-injection": "true"
               },
+              "creationTimestamp": "2025-08-15T13:11:29Z",
               "labels": {
                 "app.kubernetes.io/managed-by": "cert-manager-webhook"
               },
               "name": "cert-manager-webhook-ca",
               "namespace": "cert-manager",
+              "resourceVersion": "748",
               "uid": "e11953ff-fbd0-4a68-8dc3-95f3a9dd1087"
             },
             "type": "Opaque"
           }
+        },
    "data-gatherer": "k8s/secrets",
     "schema_version": "v2.0.0",
-    "timestamp": "2025-08-19T16:34:41+01:00"
+    "timestamp": "2025-08-19T16:34:13+01:00"
   }
 ]
```


