### PR TITLE
[VC-43403] Add Local File output path mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,19 @@ To build and run a version from master:
 go run main.go agent --agent-config-file ./path/to/agent/config/file.yaml -p 0h1m0s
 ```
 
-You can find an example agent file [here](https://github.com/jetstack/preflight/blob/master/agent.yaml).
+You can configure the agent to perform one data gathering loop and output the data to a local file:
+
+```bash
+go run . agent \
+   --agent-config-file examples/one-shot-secret.yaml \
+   --one-shot \
+   --output-path output.json
+```
+
+> Some examples of agent configuration files:
+> - [./agent.yaml](./agent.yaml).
+> - [./examples/one-shot-secret.yaml](./examples/one-shot-secret.yaml).
+> - [./examples/cert-manager-agent.yaml](./examples/cert-manager-agent.yaml).
 
 You might also want to run a local echo server to monitor requests sent by the agent:
 

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -19,8 +19,6 @@ func TestAgentRunOneShot(t *testing.T) {
 			"preflight",
 			"agent",
 			"--one-shot",
-			// TODO(wallrj): This should not be required when an `--input-file` has been supplied.
-			"--api-token=should-not-be-required",
 			"--agent-config-file=testdata/agent/one-shot/success/config.yaml",
 			"--input-path=testdata/agent/one-shot/success/input.json",
 			"--output-path=/dev/null",

--- a/examples/one-shot-secret.yaml
+++ b/examples/one-shot-secret.yaml
@@ -4,7 +4,7 @@
 # It gathers only secrets and it does not attempt to upload to Venafi.
 # For example:
 #
-#  builds/preflight agent \
+#  go run . agent \
 #     --agent-config-file examples/one-shot-secret.yaml \
 #     --one-shot \
 #     --output-path output.json

--- a/pkg/client/client_file.go
+++ b/pkg/client/client_file.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"k8s.io/klog/v2"
+
+	"github.com/jetstack/preflight/api"
+)
+
+// FileClient writes the supplied readings to a file, in JSON format.
+type FileClient struct {
+	path string
+}
+
+func NewFileClient(path string) Client {
+	return &FileClient{
+		path: path,
+	}
+}
+
+func (o *FileClient) PostDataReadingsWithOptions(ctx context.Context, readings []*api.DataReading, _ Options) error {
+	log := klog.FromContext(ctx)
+	data, err := json.MarshalIndent(readings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %s", err)
+	}
+	err = os.WriteFile(o.path, data, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write file: %s", err)
+	}
+	log.Info("Data saved to local file", "outputPath", o.path)
+	return nil
+}

--- a/pkg/client/client_file_test.go
+++ b/pkg/client/client_file_test.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+
+	"github.com/jetstack/preflight/api"
+)
+
+func TestFileClient_PostDataReadingsWithOptions(t *testing.T) {
+	type testCase struct {
+		name          string
+		path          string
+		readings      []*api.DataReading
+		expectedJSON  string
+		expectedError string
+	}
+	tests := []testCase{
+		{
+			name:         "success",
+			path:         "{tmp}/data.json",
+			readings:     []*api.DataReading{},
+			expectedJSON: "[]",
+		},
+		{
+			name:         "success-overwrite",
+			path:         "{tmp}/exists.json",
+			readings:     []*api.DataReading{},
+			expectedJSON: "[]",
+		},
+		{
+			name: "json-marshal-error",
+			path: "{tmp}/data.json",
+			readings: []*api.DataReading{
+				{
+					Data: json.RawMessage("x"),
+				},
+			},
+			expectedError: "failed to marshal JSON: json: error calling MarshalJSON for type json.RawMessage: invalid character 'x' looking for beginning of value",
+			expectedJSON:  "[]",
+		},
+		{
+			name:          "no-such-file-or-directory",
+			path:          "{tmp}/no-such-folder/data.json",
+			readings:      []*api.DataReading{},
+			expectedError: "failed to write file: open {tmp}/no-such-folder/data.json: no such file or directory",
+			expectedJSON:  "[]",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			log := ktesting.NewLogger(t, ktesting.DefaultConfig)
+			ctx := klog.NewContext(t.Context(), log)
+			tmpDir := t.TempDir()
+			require.NoError(t, os.WriteFile(tmpDir+"/exists.json", []byte("existing-content"), 0644))
+
+			path := strings.ReplaceAll(tc.path, "{tmp}", tmpDir)
+			expectedError := strings.ReplaceAll(tc.expectedError, "{tmp}", tmpDir)
+
+			c := NewFileClient(path)
+			err := c.PostDataReadingsWithOptions(ctx, tc.readings, Options{})
+
+			if expectedError != "" {
+				assert.EqualError(t, err, expectedError)
+				return
+			}
+			require.NoError(t, err)
+			assert.FileExists(t, path)
+			actualJSON, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.expectedJSON, string(actualJSON))
+		})
+	}
+}


### PR DESCRIPTION
Changes:
- Refactored TLSPKMode to a more general OutputMode.
- Added a new Local File output mode.

Next I'd like to add a MachineHub mode:
 * #696 

Later I'll try and figure how we can allow multiple output modes.

## Testing

```
$ go run . agent    --agent-config-file examples/one-shot-secret.yaml    --one-shot    --output-path output.json
I0822 12:06:42.354685  284845 run.go:58] "Starting" logger="Run" version="development" commit=""
I0822 12:06:42.355219  284845 run.go:116] "Healthz endpoints enabled" logger="Run.APIServer" addr=":8081" path="/healthz"
I0822 12:06:42.355273  284845 run.go:120] "Readyz endpoints enabled" logger="Run.APIServer" addr=":8081" path="/readyz"
I0822 12:06:42.355300  284845 run.go:269] "Pod event recorder disabled" logger="Run" reason="The agent does not appear to be running in a Kubernetes cluster." detail="When running in a Kubernetes cluster the following environment variables must be set: POD_NAME, POD_NODE, POD_UID, POD_NAMESPACE"
I0822 12:06:42.558945  284845 client_file.go:35] "Data saved to local file" logger="Run.gatherAndOutputData.postData" outputPath="output.json"
I0822 12:06:42.558992  284845 run.go:417] "Data sent successfully" logger="Run.gatherAndOutputData.postData"

$ jq  -r '.[] | .data.items[] | .resource.metadata | "\(.namespace)/\(.name)"' < output.json
gmp-system/collection
gmp-system/rules
gmp-system/webhook-tls
team-1/app-0
venafi/cert-manager-approver-policy-tls
venafi/cert-manager-webhook-ca
default/venafi-kubernetes-agent-e2e.a2074131-f85a-48c0-88be-fb1a1d871a3b
gmp-system/alertmanager
```
