### PR TITLE
[VC-43403] Refactor the CyberArk identity client to take an HTTP client

### DIFF
--- a/pkg/internal/cyberark/identity/advance_authentication_test.go
+++ b/pkg/internal/cyberark/identity/advance_authentication_test.go
@@ -99,21 +99,11 @@ func Test_IdentityAdvanceAuthentication(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := t.Context()
 
-			identityServer := MockIdentityServer()
-			defer identityServer.Close()
+			identityAPI, httpClient := MockIdentityServer(t)
 
-			mockDiscoveryServer := servicediscovery.MockDiscoveryServerWithCustomAPIURL(identityServer.Server.URL)
-			defer mockDiscoveryServer.Close()
+			client := New(httpClient, identityAPI, servicediscovery.MockDiscoverySubdomain)
 
-			discoveryClient := servicediscovery.New(servicediscovery.WithCustomEndpoint(mockDiscoveryServer.Server.URL))
-
-			client, err := NewWithDiscoveryClient(ctx, discoveryClient, servicediscovery.MockDiscoverySubdomain)
-			if err != nil {
-				t.Errorf("failed to create identity client: %s", err)
-				return
-			}
-
-			err = client.doAdvanceAuthentication(ctx, testSpec.username, &testSpec.password, testSpec.advanceBody)
+			err := client.doAdvanceAuthentication(ctx, testSpec.username, &testSpec.password, testSpec.advanceBody)
 			if testSpec.expectedError != err {
 				if testSpec.expectedError == nil {
 					t.Errorf("didn't expect an error but got %v", err)

--- a/pkg/internal/cyberark/identity/start_authentication_test.go
+++ b/pkg/internal/cyberark/identity/start_authentication_test.go
@@ -40,19 +40,9 @@ func Test_IdentityStartAuthentication(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := t.Context()
 
-			identityServer := MockIdentityServer()
-			defer identityServer.Close()
+			identityServer, httpClient := MockIdentityServer(t)
 
-			mockDiscoveryServer := servicediscovery.MockDiscoveryServerWithCustomAPIURL(identityServer.Server.URL)
-			defer mockDiscoveryServer.Close()
-
-			discoveryClient := servicediscovery.New(servicediscovery.WithCustomEndpoint(mockDiscoveryServer.Server.URL))
-
-			client, err := NewWithDiscoveryClient(ctx, discoveryClient, servicediscovery.MockDiscoverySubdomain)
-			if err != nil {
-				t.Errorf("failed to create identity client: %s", err)
-				return
-			}
+			client := New(httpClient, identityServer, servicediscovery.MockDiscoverySubdomain)
 
 			advanceBody, err := client.doStartAuthentication(ctx, testSpec.username)
 			if err != nil {

--- a/pkg/internal/cyberark/servicediscovery/discovery.go
+++ b/pkg/internal/cyberark/servicediscovery/discovery.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	prodDiscoveryEndpoint        = "https://platform-discovery.cyberark.cloud/api/v2/"
-	integrationDiscoveryEndpoint = "https://platform-discovery.integration-cyberark.cloud/api/v2/"
+	ProdDiscoveryEndpoint = "https://platform-discovery.cyberark.cloud/api/v2/"
 
 	// identityServiceName is the name of the identity service we're looking for in responses from the Service Discovery API
 	// We were told to use the identity_administration field, not the identity_user_portal field.
@@ -45,13 +44,6 @@ func WithHTTPClient(httpClient *http.Client) ClientOpt {
 	}
 }
 
-// WithIntegrationEndpoint sets the discovery client to use the integration testing endpoint rather than production
-func WithIntegrationEndpoint() ClientOpt {
-	return func(c *Client) {
-		c.endpoint = integrationDiscoveryEndpoint
-	}
-}
-
 // WithCustomEndpoint sets the endpoint to a custom URL without checking that the URL is a CyberArk Service Discovery
 // server.
 func WithCustomEndpoint(endpoint string) ClientOpt {
@@ -67,7 +59,7 @@ func New(clientOpts ...ClientOpt) *Client {
 			Timeout:   10 * time.Second,
 			Transport: transport.NewDebuggingRoundTripper(http.DefaultTransport, transport.DebugByContext),
 		},
-		endpoint: prodDiscoveryEndpoint,
+		endpoint: ProdDiscoveryEndpoint,
 	}
 
 	for _, opt := range clientOpts {


### PR DESCRIPTION
I'm refactoring the CyberArk identity client to be less dependent on the service discovery client.
This detangles the those two packages and simplifies things. 

The identity client interacts with the CyberArk authentication API.
The discoveryservice client retrieves a list of the services that are enabled for a particular tenant along with the associated API URLs.

The identity client now takes an identityAPI url parameter instead of a discovery client.
So we can test it in isolation.

I'm refactoring the various CyberArk API clients, so that we can more easily pass in a shared and customized HTTP client which will be used by all the of them. 
Ultimately, I want to instantiate a single `http_client.NewDefaultClient` (from venafi-connection-lib) and supply it to all the CyberArk API wrappers. That client has a builtin retry mechanism and builtin user-agent header injection.

This also makes it easier to pass in a client that is matched to an `httptest.NewTLSServer`; one configured with the CA certificates to connect to the server.

## Followups
* #699 
* #700 
* #701
* #696

## Testing

```bash
export ARK_USERNAME=****
export ARK_SECRET=****
export ARK_SUBDOMAIN=tlskp-test
export ARK_PLATFORM_DOMAIN=integration-cyberark.cloud
export ARK_DISCOVERY_API=https://platform-discovery.integration-cyberark.cloud/api/v2
```

```bash
$ go run ./pkg/internal/cyberark/identity/cmd/testidentity/main.go  --username $ARK_USERNAME --subdomain $ARK_SUBDOMAIN
I0827 11:40:15.890540  557774 round_trippers.go:632] "Response" verb="GET" url="https://platform-discovery.integration-cyberark.cloud/api/v2/services/subdomain/tlskp-test" status="200 OK" milliseconds=242
I0827 11:40:16.677861  557774 round_trippers.go:632] "Response" verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/StartAuthentication" status="200 OK" milliseconds=785
I0827 11:40:16.679219  557774 identity.go:303] "made successful request to StartAuthentication" source="Identity.doStartAuthentication" summary="NewPackage"
I0827 11:40:17.369865  557774 round_trippers.go:632] "Response" verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/AdvanceAuthentication" status="200 OK" milliseconds=690
I0827 11:40:17.371148  557774 identity.go:419] "successfully completed AdvanceAuthentication request to CyberArk Identity; login complete" username="<REDACTED>"
```

```bash
$ go test ./pkg/internal/cyberark/dataupload/... -v -run RealAPI -args -testing.v 6
=== RUN   TestPostDataReadingsWithOptionsWithRealAPI
    round_trippers.go:632: I0827 11:43:17.911596] Response verb="GET" url="https://platform-discovery.integration-cyberark.cloud/api/v2/services/subdomain/tlskp-test" status="200 OK" milliseconds=279
    round_trippers.go:632: I0827 11:43:18.288517] Response verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/StartAuthentication" status="200 OK" milliseconds=375
    identity.go:303: I0827 11:43:18.289432] made successful request to StartAuthentication source="Identity.doStartAuthentication" summary="NewPackage"
    round_trippers.go:632: I0827 11:43:18.716915] Response verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/AdvanceAuthentication" status="200 OK" milliseconds=426
    identity.go:419: I0827 11:43:18.717787] successfully completed AdvanceAuthentication request to CyberArk Identity; login complete username="<REDACTED>"
    round_trippers.go:632: I0827 11:43:19.349515] Response verb="POST" url="https://tlskp-test.inventory.integration-cyberark.cloud/api/ingestions/kubernetes/snapshot-links" status="200 OK" milliseconds=631
    round_trippers.go:632: I0827 11:43:19.834370] Response verb="PUT" url="<REDACTED>" status="200 OK" milliseconds=484
--- PASS: TestPostDataReadingsWithOptionsWithRealAPI (2.20s)
PASS
ok      github.com/jetstack/preflight/pkg/internal/cyberark/dataupload  2.267s
```