### PR TITLE
[VC-43403] Refactor the CyberArk servicediscovery client to take an HTTP client

### DIFF
--- a/pkg/internal/cyberark/dataupload/dataupload_test.go
+++ b/pkg/internal/cyberark/dataupload/dataupload_test.go
@@ -144,10 +144,6 @@ func TestPostDataReadingsWithOptionsWithRealAPI(t *testing.T) {
 	subdomain := os.Getenv("ARK_SUBDOMAIN")
 	username := os.Getenv("ARK_USERNAME")
 	secret := os.Getenv("ARK_SECRET")
-	serviceDiscoveryAPI := os.Getenv("ARK_DISCOVERY_API")
-	if serviceDiscoveryAPI == "" {
-		serviceDiscoveryAPI = servicediscovery.ProdDiscoveryEndpoint
-	}
 
 	if platformDomain == "" || subdomain == "" || username == "" || secret == "" {
 		t.Skip("Skipping because one of the following environment variables is unset or empty: ARK_PLATFORM_DOMAIN, ARK_SUBDOMAIN, ARK_USERNAME, ARK_SECRET")
@@ -168,10 +164,7 @@ func TestPostDataReadingsWithOptionsWithRealAPI(t *testing.T) {
 	httpClient := http_client.NewDefaultClient(version.UserAgent(), rootCAs)
 	httpClient.Transport = transport.NewDebuggingRoundTripper(httpClient.Transport, transport.DebugByContext)
 
-	discoveryClient := servicediscovery.New(
-		servicediscovery.WithHTTPClient(httpClient),
-		servicediscovery.WithCustomEndpoint(serviceDiscoveryAPI),
-	)
+	discoveryClient := servicediscovery.New(httpClient)
 
 	identityAPI, err := discoveryClient.DiscoverIdentityAPIURL(ctx, subdomain)
 	require.NoError(t, err)

--- a/pkg/internal/cyberark/identity/cmd/testidentity/main.go
+++ b/pkg/internal/cyberark/identity/cmd/testidentity/main.go
@@ -24,10 +24,9 @@ import (
 // To test against a tenant on the integration platform, set:
 // ARK_DISCOVERY_API=https://platform-discovery.integration-cyberark.cloud/api/v2
 const (
-	subdomainFlag          = "subdomain"
-	usernameFlag           = "username"
-	passwordEnv            = "ARK_SECRET"
-	serviceDiscoveryAPIEnv = "ARK_DISCOVERY_API"
+	subdomainFlag = "subdomain"
+	usernameFlag  = "username"
+	passwordEnv   = "ARK_SECRET"
 )
 
 var (
@@ -49,19 +48,11 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("no password provided in %s", passwordEnv)
 	}
 
-	serviceDiscoveryAPI := os.Getenv(serviceDiscoveryAPIEnv)
-	if serviceDiscoveryAPI == "" {
-		serviceDiscoveryAPI = servicediscovery.ProdDiscoveryEndpoint
-	}
-
 	var rootCAs *x509.CertPool
 	httpClient := http_client.NewDefaultClient(version.UserAgent(), rootCAs)
 	httpClient.Transport = transport.NewDebuggingRoundTripper(httpClient.Transport, transport.DebugByContext)
 
-	sdClient := servicediscovery.New(
-		servicediscovery.WithHTTPClient(httpClient),
-		servicediscovery.WithCustomEndpoint(serviceDiscoveryAPI),
-	)
+	sdClient := servicediscovery.New(httpClient)
 	identityAPI, err := sdClient.DiscoverIdentityAPIURL(ctx, subdomain)
 	if err != nil {
 		return fmt.Errorf("while performing service discovery: %s", err)

--- a/pkg/internal/cyberark/servicediscovery/discovery_test.go
+++ b/pkg/internal/cyberark/servicediscovery/discovery_test.go
@@ -3,6 +3,11 @@ package servicediscovery
 import (
 	"fmt"
 	"testing"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+
+	_ "k8s.io/klog/v2/ktesting/init"
 )
 
 func Test_DiscoverIdentityAPIURL(t *testing.T) {
@@ -45,12 +50,12 @@ func Test_DiscoverIdentityAPIURL(t *testing.T) {
 
 	for name, testSpec := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := t.Context()
+			logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
+			ctx := klog.NewContext(t.Context(), logger)
 
-			ts := MockDiscoveryServer()
-			defer ts.Close()
+			httpClient := MockDiscoveryServer(t, mockIdentityAPIURL)
 
-			client := New(WithCustomEndpoint(ts.Server.URL))
+			client := New(httpClient)
 
 			apiURL, err := client.DiscoverIdentityAPIURL(ctx, testSpec.subdomain)
 			if err != nil {


### PR DESCRIPTION
- Removed `WithCustomEndpoint` and `WithHTTPClient` options from the `servicediscovery.Client`.
- Updated `New` function to directly use `http.Client` and fetch the base URL from the `ARK_DISCOVERY_API` environment variable.
- Replaced `ProdDiscoveryEndpoint` constant with `ProdDiscoveryAPIBaseURL` for clarity.
- Refactored tests to use `testing.T` cleanup and environment variable setup for mock servers.
- Simplified test setup by removing redundant mock server initialization steps.

## Follow up PRs
* #700 
* #701 
* #696 

## Testing

Example of the extra logging from the tests, which helps diagnose test failures and helps to understand what API requests the client is making:
```
$ go test ./pkg/internal/cyberark/servicediscovery/... -v -args -testing.v 6
=== RUN   Test_DiscoverIdentityAPIURL
=== RUN   Test_DiscoverIdentityAPIURL/successful_request
    mock.go:69: GET /services/subdomain/venafi-test
    round_trippers.go:632: I0827 17:33:38.601555] Response verb="GET" url="https://127.0.0.1:36789/services/subdomain/venafi-test" status="200 OK" milliseconds=2
=== RUN   Test_DiscoverIdentityAPIURL/subdomain_not_found
    mock.go:69: GET /services/subdomain/something-random
    round_trippers.go:632: I0827 17:33:38.605067] Response verb="GET" url="https://127.0.0.1:35145/services/subdomain/something-random" status="404 Not Found" milliseconds=3
=== RUN   Test_DiscoverIdentityAPIURL/no_identity_service_in_response
    mock.go:69: GET /services/subdomain/no-identity
    round_trippers.go:632: I0827 17:33:38.607924] Response verb="GET" url="https://127.0.0.1:40485/services/subdomain/no-identity" status="200 OK" milliseconds=1
=== RUN   Test_DiscoverIdentityAPIURL/unexpected_HTTP_response
    mock.go:69: GET /services/subdomain/bad-request
    round_trippers.go:632: I0827 17:33:38.610534] Response verb="GET" url="https://127.0.0.1:36017/services/subdomain/bad-request" status="400 Bad Request" milliseconds=2
=== RUN   Test_DiscoverIdentityAPIURL/response_JSON_too_long
    mock.go:69: GET /services/subdomain/json-too-long
    round_trippers.go:632: I0827 17:33:38.696813] Response verb="GET" url="https://127.0.0.1:36707/services/subdomain/json-too-long" status="200 OK" milliseconds=85
=== RUN   Test_DiscoverIdentityAPIURL/response_JSON_invalid
    mock.go:69: GET /services/subdomain/json-invalid
    round_trippers.go:632: I0827 17:33:38.708833] Response verb="GET" url="https://127.0.0.1:32793/services/subdomain/json-invalid" status="200 OK" milliseconds=2
--- PASS: Test_DiscoverIdentityAPIURL (0.11s)
    --- PASS: Test_DiscoverIdentityAPIURL/successful_request (0.00s)
    --- PASS: Test_DiscoverIdentityAPIURL/subdomain_not_found (0.00s)
    --- PASS: Test_DiscoverIdentityAPIURL/no_identity_service_in_response (0.00s)
    --- PASS: Test_DiscoverIdentityAPIURL/unexpected_HTTP_response (0.00s)
    --- PASS: Test_DiscoverIdentityAPIURL/response_JSON_too_long (0.09s)
    --- PASS: Test_DiscoverIdentityAPIURL/response_JSON_invalid (0.00s)
PASS
ok      github.com/jetstack/preflight/pkg/internal/cyberark/servicediscovery    0.118s
```
