### PR TITLE
[VC-43403] Refactor the CyberArk dataupload client to take an HTTP client

### DIFF
--- a/pkg/client/client_cyberark.go
+++ b/pkg/client/client_cyberark.go
@@ -6,4 +6,4 @@ import (
 
 type CyberArkClient = dataupload.CyberArkClient
 
-var NewCyberArkClient = dataupload.NewCyberArkClient
+var NewCyberArkClient = dataupload.New


### PR DESCRIPTION
Similar to #699, I want all the cyberark API wrappers to take an httpClient as an injected dependency rather than them each instantiating their own client. This way the http client can be created once, with sensible defaults and roundtrippers, and supplied to all the API wrappers.

- Replaced `NewCyberArkClient` with `New` to simplify client initialization
  by removing certificate pool handling and relying on an injected HTTP client.
- Updated `CyberArkClient` to use `httpClient` instead of `client` for clarity.
- Refactored `MockDataUploadServer` to return both server URL and HTTP client,
  improving test setup and reducing boilerplate.
- Removed unused imports and redundant code in `dataupload_test.go` and `mock.go`.

## Follow up PRs
* #701 
* #703 
* #696 

