### PR TITLE
[VC-43403] CyberArk(identity): enhance test logging and context handling

### DIFF
--- a/pkg/internal/cyberark/identity/advance_authentication_test.go
+++ b/pkg/internal/cyberark/identity/advance_authentication_test.go
@@ -4,7 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+
 	"github.com/jetstack/preflight/pkg/internal/cyberark/servicediscovery"
+
+	_ "k8s.io/klog/v2/ktesting/init"
 )
 
 func Test_IdentityAdvanceAuthentication(t *testing.T) {
@@ -97,7 +102,8 @@ func Test_IdentityAdvanceAuthentication(t *testing.T) {
 
 	for name, testSpec := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := t.Context()
+			logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
+			ctx := klog.NewContext(t.Context(), logger)
 
 			identityAPI, httpClient := MockIdentityServer(t)
 

--- a/pkg/internal/cyberark/identity/mock.go
+++ b/pkg/internal/cyberark/identity/mock.go
@@ -54,12 +54,16 @@ var (
 	advanceAuthenticationFailureResponse string
 )
 
-type mockIdentityServer struct{}
+type mockIdentityServer struct {
+	t testing.TB
+}
 
 // MockIdentityServer returns a URL of a mocked CyberArk identity server and an
 // HTTP client with the CA certs needed to connect to it..
-func MockIdentityServer(t *testing.T) (string, *http.Client) {
-	mis := &mockIdentityServer{}
+func MockIdentityServer(t testing.TB) (string, *http.Client) {
+	mis := &mockIdentityServer{
+		t: t,
+	}
 	server := httptest.NewTLSServer(mis)
 	t.Cleanup(server.Close)
 	httpClient := server.Client()
@@ -68,6 +72,7 @@ func MockIdentityServer(t *testing.T) (string, *http.Client) {
 }
 
 func (mis *mockIdentityServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	mis.t.Log(r.Method, r.RequestURI)
 	switch r.URL.String() {
 	case "/Security/StartAuthentication":
 		mis.handleStartAuthentication(w, r)


### PR DESCRIPTION
Some things I forgot to commit to #698 :
- Integrated klog for improved logging in identity tests
- Updated `MockIdentityServer` to use `testing.TB` for broader compatibility
- Added request logging in `mockIdentityServer.ServeHTTP` for better debugging

## Testing

The extra logging helps understand what's going on if and when the tests fail:
```
$ go test ./pkg/internal/cyberark/identity/... -v -args -testing.v 6
=== RUN   Test_IdentityAdvanceAuthentication
=== RUN   Test_IdentityAdvanceAuthentication/persistent_login_not_set
    mock.go:75: POST /Security/AdvanceAuthentication
    round_trippers.go:632: I0827 17:12:58.518756] Response verb="POST" url="https://127.0.0.1:46037/Security/AdvanceAuthentication" status="403 Forbidden" milliseconds=3
=== RUN   Test_IdentityAdvanceAuthentication/success
    mock.go:75: POST /Security/AdvanceAuthentication
    round_trippers.go:632: I0827 17:12:58.522964] Response verb="POST" url="https://127.0.0.1:43719/Security/AdvanceAuthentication" status="200 OK" milliseconds=2
    identity.go:419: I0827 17:12:58.523056] successfully completed AdvanceAuthentication request to CyberArk Identity; login complete username="test@example.com"
=== RUN   Test_IdentityAdvanceAuthentication/incorrect_password
    mock.go:75: POST /Security/AdvanceAuthentication
    round_trippers.go:632: I0827 17:12:58.525780] Response verb="POST" url="https://127.0.0.1:44419/Security/AdvanceAuthentication" status="200 OK" milliseconds=2
=== RUN   Test_IdentityAdvanceAuthentication/bad_action
    mock.go:75: POST /Security/AdvanceAuthentication
    round_trippers.go:632: I0827 17:12:58.530060] Response verb="POST" url="https://127.0.0.1:46513/Security/AdvanceAuthentication" status="200 OK" milliseconds=3
=== RUN   Test_IdentityAdvanceAuthentication/bad_mechanism_id
    mock.go:75: POST /Security/AdvanceAuthentication
    round_trippers.go:632: I0827 17:12:58.534118] Response verb="POST" url="https://127.0.0.1:36853/Security/AdvanceAuthentication" status="200 OK" milliseconds=2
=== RUN   Test_IdentityAdvanceAuthentication/bad_session_id
    mock.go:75: POST /Security/AdvanceAuthentication
    round_trippers.go:632: I0827 17:12:58.538477] Response verb="POST" url="https://127.0.0.1:33319/Security/AdvanceAuthentication" status="200 OK" milliseconds=3
--- PASS: Test_IdentityAdvanceAuthentication (0.02s)
    --- PASS: Test_IdentityAdvanceAuthentication/persistent_login_not_set (0.01s)
    --- PASS: Test_IdentityAdvanceAuthentication/success (0.00s)
    --- PASS: Test_IdentityAdvanceAuthentication/incorrect_password (0.00s)
    --- PASS: Test_IdentityAdvanceAuthentication/bad_action (0.01s)
    --- PASS: Test_IdentityAdvanceAuthentication/bad_mechanism_id (0.00s)
    --- PASS: Test_IdentityAdvanceAuthentication/bad_session_id (0.00s)
=== RUN   Test_IdentityStartAuthentication
=== RUN   Test_IdentityStartAuthentication/successful_request
    mock.go:75: POST /Security/StartAuthentication
=== RUN   Test_IdentityStartAuthentication/successful_request,_multiple_challenges
    mock.go:75: POST /Security/StartAuthentication
=== RUN   Test_IdentityStartAuthentication/successful_request,_multiple_mechanisms
    mock.go:75: POST /Security/StartAuthentication
=== RUN   Test_IdentityStartAuthentication/successful_request,_no_username_/_password_(UP)_mechanism_available
    mock.go:75: POST /Security/StartAuthentication
=== RUN   Test_IdentityStartAuthentication/failed_request
    mock.go:75: POST /Security/StartAuthentication
--- PASS: Test_IdentityStartAuthentication (0.02s)
    --- PASS: Test_IdentityStartAuthentication/successful_request (0.00s)
    --- PASS: Test_IdentityStartAuthentication/successful_request,_multiple_challenges (0.00s)
    --- PASS: Test_IdentityStartAuthentication/successful_request,_multiple_mechanisms (0.00s)
    --- PASS: Test_IdentityStartAuthentication/successful_request,_no_username_/_password_(UP)_mechanism_available (0.00s)
    --- PASS: Test_IdentityStartAuthentication/failed_request (0.00s)
PASS
ok      github.com/jetstack/preflight/pkg/internal/cyberark/identity    0.054s
?       github.com/jetstack/preflight/pkg/internal/cyberark/identity/cmd/testidentity   [no test files]
```