### PR TITLE
[VC-43403] CyberArk(dataupload): replace PostDataReadingsWithOptions with PutSnapshot

### DIFF
--- a/pkg/internal/cyberark/dataupload/dataupload.go
+++ b/pkg/internal/cyberark/dataupload/dataupload.go
@@ -12,7 +12,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/jetstack/preflight/api"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/jetstack/preflight/pkg/version"
 )
 
@@ -46,7 +47,43 @@ func New(httpClient *http.Client, baseURL string, authenticateRequest func(req *
 	}
 }
 
-// PostDataReadingsWithOptions PUTs the supplied payload to an [AWS presigned URL] which it obtains via the CyberArk inventory API.
+// Snapshot is the JSON that the CyberArk Discovery and Context API expects to
+// be uploaded to the AWS presigned URL.
+type Snapshot struct {
+	// AgentVersion is the version of the Venafi Kubernetes Agent which is uploading this snapshot.
+	AgentVersion string `json:"agent_version"`
+	// ClusterID is the unique ID of the Kubernetes cluster which this snapshot was taken from.
+	ClusterID string `json:"cluster_id"`
+	// K8SVersion is the version of Kubernetes which the cluster is running.
+	K8SVersion string `json:"k8s_version"`
+	// Secrets is a list of Secret resources in the cluster. Not all Secret
+	// types are included and only a subset of the Secret data is included.
+	Secrets []*unstructured.Unstructured `json:"secrets"`
+	// ServiceAccounts is a list of ServiceAccount resources in the cluster.
+	ServiceAccounts []*unstructured.Unstructured `json:"serviceaccounts"`
+	// Roles is a list of Role resources in the cluster.
+	Roles []*unstructured.Unstructured `json:"roles"`
+	// ClusterRoles is a list of ClusterRole resources in the cluster.
+	ClusterRoles []*unstructured.Unstructured `json:"clusterroles"`
+	// RoleBindings is a list of RoleBinding resources in the cluster.
+	RoleBindings []*unstructured.Unstructured `json:"rolebindings"`
+	// ClusterRoleBindings is a list of ClusterRoleBinding resources in the cluster.
+	ClusterRoleBindings []*unstructured.Unstructured `json:"clusterrolebindings"`
+	// Jobs is a list of Job resources in the cluster.
+	Jobs []*unstructured.Unstructured `json:"jobs"`
+	// CronJobs is a list of CronJob resources in the cluster.
+	CronJobs []*unstructured.Unstructured `json:"cronjobs"`
+	// Deployments is a list of Deployment resources in the cluster.
+	Deployments []*unstructured.Unstructured `json:"deployments"`
+	// Statefulsets is a list of StatefulSet resources in the cluster.
+	Statefulsets []*unstructured.Unstructured `json:"statefulsets"`
+	// Daemonsets is a list of DaemonSet resources in the cluster.
+	Daemonsets []*unstructured.Unstructured `json:"daemonsets"`
+	// Pods is a list of Pod resources in the cluster.
+	Pods []*unstructured.Unstructured `json:"pods"`
+}
+
+// PutSnapshot PUTs the supplied snapshot to an [AWS presigned URL] which it obtains via the CyberArk inventory API.
 // [AWS presigned URL]: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
 //
 // A SHA256 checksum header is included in the request, to verify that the payload
@@ -60,20 +97,20 @@ func New(httpClient *http.Client, baseURL string, authenticateRequest func(req *
 // If you omit that header, it is possible to PUT any data.
 // There is a work around listed in that issue which we have shared with the
 // CyberArk API team.
-func (c *CyberArkClient) PostDataReadingsWithOptions(ctx context.Context, payload api.DataReadingsPost, opts Options) error {
-	if opts.ClusterName == "" {
-		return fmt.Errorf("programmer mistake: the cluster name (aka `cluster_id` in the config file) cannot be left empty")
+func (c *CyberArkClient) PutSnapshot(ctx context.Context, snapshot Snapshot) error {
+	if snapshot.ClusterID == "" {
+		return fmt.Errorf("programmer mistake: the snapshot cluster ID cannot be left empty")
 	}
 
 	encodedBody := &bytes.Buffer{}
 	hash := sha256.New()
-	if err := json.NewEncoder(io.MultiWriter(encodedBody, hash)).Encode(payload); err != nil {
+	if err := json.NewEncoder(io.MultiWriter(encodedBody, hash)).Encode(snapshot); err != nil {
 		return err
 	}
 	checksum := hash.Sum(nil)
 	checksumHex := hex.EncodeToString(checksum)
 	checksumBase64 := base64.StdEncoding.EncodeToString(checksum)
-	presignedUploadURL, err := c.retrievePresignedUploadURL(ctx, checksumHex, opts)
+	presignedUploadURL, err := c.retrievePresignedUploadURL(ctx, checksumHex, snapshot.ClusterID)
 	if err != nil {
 		return fmt.Errorf("while retrieving snapshot upload URL: %s", err)
 	}
@@ -103,7 +140,7 @@ func (c *CyberArkClient) PostDataReadingsWithOptions(ctx context.Context, payloa
 	return nil
 }
 
-func (c *CyberArkClient) retrievePresignedUploadURL(ctx context.Context, checksum string, opts Options) (string, error) {
+func (c *CyberArkClient) retrievePresignedUploadURL(ctx context.Context, checksum string, clusterID string) (string, error) {
 	uploadURL, err := url.JoinPath(c.baseURL, apiPathSnapshotLinks)
 	if err != nil {
 		return "", err
@@ -114,7 +151,7 @@ func (c *CyberArkClient) retrievePresignedUploadURL(ctx context.Context, checksu
 		Checksum     string `json:"checksum_sha256"`
 		AgentVersion string `json:"agent_version"`
 	}{
-		ClusterID:    opts.ClusterName,
+		ClusterID:    clusterID,
 		Checksum:     checksum,
 		AgentVersion: version.PreflightVersion,
 	}


### PR DESCRIPTION
Stacked on #701 

Trying to untangle the CyberArk dataupload API wrapper from the DataReadings API of the agent.
The conversion between DataReadings and Snapshot will be implemented in a followup PR.

- Introduced a new `Snapshot` struct to represent the payload for the CyberArk Discovery and Context API.
- Replaced the `PostDataReadingsWithOptions` method with `PutSnapshot`, which now uses the `Snapshot` struct and removes the dependency on `api.DataReadingsPost`.
- Updated the `retrievePresignedUploadURL` method to accept `clusterID` directly instead of relying on `Options`.
- Refactored tests to align with the new `PutSnapshot` method and `Snapshot` struct. Removed unused imports and legacy test cases.

## Follow up PRs
* #696 
* #684 

## Testing
I ran the data upload test with against the real API.

````bash
$ go test ./pkg/internal/cyberark/dataupload/...   -v -run RealAPI -args -testing.v 6
=== RUN   TestCyberArkClient_PutSnapshot_RealAPI
    round_trippers.go:632: I0828 13:48:33.839542] Response verb="GET" url="https://platform-discovery.integration-cyberark.cloud/api/v2/services/subdomain/tlskp-test" status="200 OK" milliseconds=325
    round_trippers.go:632: I0828 13:48:34.250080] Response verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/StartAuthentication" status="200 OK" milliseconds=408
    identity.go:303: I0828 13:48:34.250728] made successful request to StartAuthentication source="Identity.doStartAuthentication" summary="NewPackage"
    round_trippers.go:632: I0828 13:48:34.691409] Response verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/AdvanceAuthentication" status="200 OK" milliseconds=440
    identity.go:419: I0828 13:48:34.692008] successfully completed AdvanceAuthentication request to CyberArk Identity; login complete username="<REDACTED>"
    round_trippers.go:632: I0828 13:48:35.582159] Response verb="POST" url="https://tlskp-test.inventory.integration-cyberark.cloud/api/ingestions/kubernetes/snapshot-links" status="200 OK" milliseconds=889
    round_trippers.go:632: I0828 13:48:36.016095] Response verb="PUT" url="<REDACTED>" status="200 OK" milliseconds=433
--- PASS: TestCyberArkClient_PutSnapshot_RealAPI (2.50s)
PASS
ok      github.com/jetstack/preflight/pkg/internal/cyberark/dataupload  2.617s
```