### PR TITLE
fix(datareading): improve DataReading JSON parsing and error handling

### DIFF
--- a/api/datareading_test.go
+++ b/api/datareading_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJSONGatheredResourceDropsEmptyTime(t *testing.T) {
@@ -32,5 +34,180 @@ func TestJSONGatheredResourceSetsTimeWhenPresent(t *testing.T) {
 
 	if string(bytes) != expected {
 		t.Fatalf("unexpected json \ngot  %s\nwant %s", string(bytes), expected)
+	}
+}
+
+// TestDataReading_UnmarshalJSON tests the UnmarshalJSON method of DataReading
+// with various scenarios including valid and invalid JSON inputs.
+func TestDataReading_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantDataType interface{}
+		expectError  string
+	}{
+		{
+			name: "DiscoveryData type",
+			input: `{
+				"cluster_id": "61b2db64-fd70-49a6-a257-08397b9b4bae",
+				"data-gatherer": "discovery",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": {
+                    "cluster_id": "60868ebf-6e47-4184-9bc0-20bb6824e210",
+					"server_version": {
+                        "major": "1",
+                        "minor": "20",
+                        "gitVersion": "v1.20.0"
+                    }
+                },
+				"schema_version": "v1"
+			}`,
+			wantDataType: &DiscoveryData{},
+		},
+		{
+			name: "DynamicData type",
+			input: `{
+				"cluster_id": "69050b54-c61a-4384-95c3-35f890377a67",
+				"data-gatherer": "dynamic",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": {"items": []},
+				"schema_version": "v1"
+			}`,
+			wantDataType: &DynamicData{},
+		},
+		{
+			name:        "Invalid JSON",
+			input:       `not a json`,
+			expectError: "failed to parse DataReading: invalid character 'o' in literal null (expecting 'u')",
+		},
+		{
+			name: "Missing data field",
+			input: `{
+				"cluster_id": "cc5a0429-8dc4-42c8-8e3a-eece9bca15c3",
+				"data-gatherer": "missing-data-field",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading.Data for gatherer "missing-data-field": empty data`,
+		},
+		{
+			name: "Mismatched data type",
+			input: `{
+				"cluster_id": "c272b13e-b19e-4782-833f-d55a305f3c9e",
+				"data-gatherer": "unknown-data-type",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": "this should be an object",
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading.Data for gatherer "unknown-data-type": unknown type`,
+		},
+		{
+			name: "Empty data field",
+			input: `{
+				"cluster_id": "07909675-113f-4b59-ba5e-529571a191e6",
+				"data-gatherer": "empty-data",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": {},
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading.Data for gatherer "empty-data": empty data`,
+		},
+		{
+			name: "Additional field",
+			input: `{
+				"cluster_id": "11df7332-4b32-4f5a-903b-0cbbef381850",
+				"data-gatherer": "additional-field",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": {
+					"cluster_id": "60868ebf-6e47-4184-9bc0-20bb6824e210"
+				},
+				"extra_field": "should cause error",
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading: json: unknown field "extra_field"`,
+		},
+		{
+			name: "Additional data field",
+			input: `{
+				"cluster_id": "ca44c338-987e-4d57-8320-63f538db4292",
+				"data-gatherer": "additional-data-field",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": {
+					"cluster_id": "60868ebf-6e47-4184-9bc0-20bb6824e210",
+					"server_version": {
+						"major": "1",
+						"minor": "20",
+						"gitVersion": "v1.20.0"
+  					},
+					"extra_field": "should cause error"
+				},
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading.Data for gatherer "additional-data-field": unknown type`,
+		},
+		{
+			name:        "Empty JSON object",
+			input:       `{}`,
+			expectError: `failed to parse DataReading.Data for gatherer "": empty data`,
+		},
+		{
+			name: "Null data field",
+			input: `{
+				"cluster_id": "36281cb3-7f3a-4efa-9879-7c988a9715b0",
+				"data-gatherer": "null-data",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": null,
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading.Data for gatherer "null-data": empty data`,
+		},
+		{
+			name: "Empty string data field",
+			input: `{
+				"cluster_id": "7b7aa8ee-58ac-4818-9b29-c0a76296ea1d",
+				"data-gatherer": "empty-string-data",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": "",
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading.Data for gatherer "empty-string-data": unknown type`,
+		},
+		{
+			name: "Array instead of object in data field",
+			input: `{
+				"cluster_id": "94d7757f-d084-4ccb-963b-f60fece0df2d",
+				"data-gatherer": "array-data",
+				"timestamp": "2024-06-01T12:00:00Z",
+				"data": [],
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading.Data for gatherer "array-data": unknown type`,
+		},
+		{
+			name: "Incorrect timestamp format",
+			input: `{
+				"cluster_id": "d58f298d-b8c1-4d99-aa85-c27d9aec6f97",
+				"data-gatherer": "bad-timestamp",
+				"timestamp": "not-a-timestamp",
+				"data": {
+					"items": []
+				},
+				"schema_version": "v1"
+			}`,
+			expectError: `failed to parse DataReading: parsing time "not-a-timestamp" as "2006-01-02T15:04:05Z07:00": cannot parse "not-a-timestamp" as "2006"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dr DataReading
+			err := dr.UnmarshalJSON([]byte(tt.input))
+			if tt.expectError != "" {
+				assert.EqualError(t, err, tt.expectError)
+				return
+			}
+			assert.NoError(t, err)
+			assert.IsType(t, tt.wantDataType, dr.Data)
+		})
 	}
 }

--- a/pkg/echo/echo_test.go
+++ b/pkg/echo/echo_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/version"
+
 	"github.com/jetstack/preflight/api"
 )
 
@@ -34,8 +36,10 @@ func TestEchoServerRequestResponse(t *testing.T) {
 						ClusterID:    "test_suite_cluster",
 						DataGatherer: "dummy",
 						Timestamp:    api.Time{Time: time.Now()},
-						Data: map[string]string{
-							"test": "test",
+						Data: &api.DiscoveryData{
+							ServerVersion: &version.Info{
+								GitVersion: "v1.20.0",
+							},
 						},
 						SchemaVersion: "2.0.0",
 					},


### PR DESCRIPTION
Some improvements to the UnmarshalJSON function (which was introduced in #707):

- Refactor UnmarshalJSON to use prioritized type decoding for Data field
- Add strict unmarshalling helper to disallow unknown fields
- Return errors for empty or unknown data types in Data field
- Add unit tests for valid and invalid JSON scenarios

## Testing

The "echo server" test was using a arbitrary data type, which is no longer allowed, so I switched it to DataReading. Here's the output of the updated test:

``` shellsession
$ go test ./pkg/echo/... -v -count 1
=== RUN   TestEchoServerRequestResponse
-- POST /api/v1/datareadings -> created 201
received 1 readings:
0:
ClusterID: test_suite_cluster
Data gatherer: dummy
Timestamp: 2025-09-05T06:15:33+01:00
SchemaVersion: 2.0.0
Data: &{ClusterID: ServerVersion:v1.20.0}
-----
-- error 400 -> invalid method. Expected POST, received GET
--- PASS: TestEchoServerRequestResponse (0.00s)
PASS
ok      github.com/jetstack/preflight/pkg/echo  0.010s
```

The machinehub outputmode test still works:

``` shellsession
go test ./cmd/... -v -count 1 -run '.*/machinehub'
=== RUN   TestOutputModes
=== RUN   TestOutputModes/machinehub
    agent_test.go:71: Running child process /tmp/go-build2356754855/b001/cmd.test -test.run=^TestOutputModes/machinehub$
    agent_test.go:80: STDOUT
        I0905 06:19:25.669617   59271 run.go:58] "Starting" logger="Run" version="development" commit=""
        I0905 06:19:25.669859   59271 config.go:448] "Output mode selected" logger="Run" mode="MachineHub" reason="--machine-hub was specified"
        I0905 06:19:25.669897   59271 run.go:116] "Healthz endpoints enabled" logger="Run.APIServer" addr=":8081" path="/healthz"
        I0905 06:19:25.669919   59271 run.go:120] "Readyz endpoints enabled" logger="Run.APIServer" addr=":8081" path="/readyz"
        I0905 06:19:25.669961   59271 run.go:269] "Pod event recorder disabled" logger="Run" reason="The agent does not appear to be running in a Kubernetes cluster." detail="When running in a Kubernetes cluster the following environment variables must be set: POD_NAME, POD_NODE, POD_UID, POD_NAMESPACE"
        I0905 06:19:25.669979   59271 run.go:308] "Reading data from local file" logger="Run.gatherAndOutputData" inputPath="/home/richard/projects/jetstack/jetstack-secure/examples/machinehub/input.json"
        I0905 06:19:25.670377   59271 run.go:432] "Starting" logger="Run.APIServer.ListenAndServe" addr=":8081"
        I0905 06:19:26.008565   59271 round_trippers.go:632] "Response" logger="Run.gatherAndOutputData.postData" verb="GET" url="https://platform-discovery.integration-cyberark.cloud/api/public/tenant-discovery?bySubdomain=tlskp-test" status="200 OK" milliseconds=337
        I0905 06:19:26.559188   59271 round_trippers.go:632] "Response" logger="Run.gatherAndOutputData.postData" verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/StartAuthentication" status="200 OK" milliseconds=548
        I0905 06:19:26.559776   59271 identity.go:292] "made successful request to StartAuthentication" logger="Run.gatherAndOutputData.postData" source="Identity.doStartAuthentication" summary="NewPackage"
        I0905 06:19:27.173640   59271 round_trippers.go:632] "Response" logger="Run.gatherAndOutputData.postData" verb="POST" url="https://anb5751.id.integration-cyberark.cloud/Security/AdvanceAuthentication" status="200 OK" milliseconds=613
        I0905 06:19:27.174260   59271 identity.go:402] "successfully completed AdvanceAuthentication request to CyberArk Identity; login complete" logger="Run.gatherAndOutputData.postData" username=""
        I0905 06:19:32.908654   59271 round_trippers.go:632] "Response" logger="Run.gatherAndOutputData.postData" verb="POST" url="https://tlskp-test.inventory.integration-cyberark.cloud/api/ingestions/kubernetes/snapshot-links" status="200 OK" milliseconds=5734
        I0905 06:19:33.378071   59271 round_trippers.go:632] "Response" logger="Run.gatherAndOutputData.postData" verb="PUT" url="" status="200 OK" milliseconds=468
        I0905 06:19:33.378305   59271 run.go:417] "Data sent successfully" logger="Run.gatherAndOutputData.postData"        
        I0905 06:19:33.378351   59271 run.go:446] "Shutting down" logger="Run.APIServer.ListenAndServe" addr=":8081"        
        I0905 06:19:33.378646   59271 run.go:461] "Shutdown complete" logger="Run.APIServer.ListenAndServe" addr=":8081"
        
    agent_test.go:81: STDERR
        
--- PASS: TestOutputModes (7.80s)
    --- PASS: TestOutputModes/machinehub (7.80s)
PASS
ok      github.com/jetstack/preflight/cmd       7.864s
```