### PR TITLE
fix(k8s): retain conjur-map key in SecretSelectedFields and tests

### DIFF
--- a/docs/datagatherers/k8s-dynamic.md
+++ b/docs/datagatherers/k8s-dynamic.md
@@ -77,7 +77,7 @@ Secrets can be gathered using the following config:
       resource: secrets
 ```
 
-Before Secrets are sent to the Preflight backend, they are redacted so no secret data is transmitted. See [`fieldfilter.go`](./../../pkg/datagatherer/k8s/fieldfilter.go) to see the details of which fields are filteres and which ones are redacted.
+Before Secrets are sent to the Preflight backend, they are redacted so no secret data is transmitted. See [`fieldfilter.go`](./../../pkg/datagatherer/k8s/fieldfilter.go) to see the details of which fields are filtered and which ones are redacted.
 
 > **All resource other than Kubernetes Secrets are sent in full, so make sure that you don't store secret information on arbitrary resources.**
 

--- a/pkg/datagatherer/k8s/fieldfilter.go
+++ b/pkg/datagatherer/k8s/fieldfilter.go
@@ -9,6 +9,9 @@ import (
 // The `data` is redacted, to prevent private keys or sensitive data being
 // collected. Only the following none-sensitive keys are retained: tls.crt,
 // ca.crt. These keys are assumed to always contain public TLS certificates.
+// The `conjur-map` key is also retained, as it is used to map Secrets to
+// Conjur variables, and is not considered sensitive.
+// See https://docs.cyberark.com/conjur-open-source/latest/en/content/integrations/k8s-ocp/cjr-secrets-provider-lp.htm
 var SecretSelectedFields = []FieldPath{
 	{"kind"},
 	{"apiVersion"},
@@ -26,6 +29,7 @@ var SecretSelectedFields = []FieldPath{
 	{"type"},
 	{"data", "tls.crt"},
 	{"data", "ca.crt"},
+	{"data", "conjur-map"},
 }
 
 // RouteSelectedFields is the list of fields sent from OpenShift Route objects to the

--- a/pkg/datagatherer/k8s/fieldfilter_test.go
+++ b/pkg/datagatherer/k8s/fieldfilter_test.go
@@ -35,8 +35,10 @@ func TestSelect(t *testing.T) {
 			},
 			"type": "kubernetes.io/tls",
 			"data": map[string]interface{}{
-				"tls.crt": "cert data",
-				"tls.key": "secret",
+				"tls.crt":    "cert data",
+				"tls.key":    "secret",
+				"extra":      "should be removed",
+				"conjur-map": "should be kept",
 			},
 		},
 		SecretSelectedFields,
@@ -61,7 +63,8 @@ func TestSelect(t *testing.T) {
 			"type": "kubernetes.io/tls",
 			"data": map[string]interface{}{
 				// The "tls.key" is ignored.
-				"tls.crt": "cert data",
+				"tls.crt":    "cert data",
+				"conjur-map": "should be kept",
 			},
 		},
 	))


### PR DESCRIPTION
- Add conjur-map to SecretSelectedFields to allow mapping secrets to Conjur
- Update tests to verify conjur-map is retained and extra keys are removed
- Reference Conjur documentation for context on conjur-map usage

Fixes: https://venafi.atlassian.net/browse/VC-43052