### PR TITLE
[VC-43403] Add filter for excluding TLS secrets without client certificates

### DIFF
--- a/deploy/charts/cyberark-disco-agent/templates/configmap.yaml
+++ b/deploy/charts/cyberark-disco-agent/templates/configmap.yaml
@@ -30,6 +30,8 @@ data:
         - type!=kubernetes.io/dockerconfigjson
         - type!=bootstrap.kubernetes.io/token
         - type!=helm.sh/release.v1
+        filters:
+        - ExcludeTLSSecretsWithoutClientCert
     - kind: k8s-dynamic
       name: ark/serviceaccounts
       config:

--- a/docs/datagatherers/k8s-dynamic.md
+++ b/docs/datagatherers/k8s-dynamic.md
@@ -106,3 +106,26 @@ when listing Secrets.
     - type!=bootstrap.kubernetes.io/token
     - type!=helm.sh/release.v1
 ```
+
+## Filters
+
+You can use filters to drop certain resources based on custom logic.
+For example, you can drop TLS secrets that do not contain any client certificates using the `ExcludeTLSSecretsWithoutClientCert` filter, as shown below:
+
+```yaml
+- kind: "k8s-dynamic"
+  name: "k8s/secrets"
+  config:
+    resource-type:
+      version: v1
+      resource: secrets
+    filters:
+    - ExcludeTLSSecretsWithoutClientCert
+```
+
+The available filters are:
+* `ExcludeTLSSecretsWithoutClientCert`: Drops TLS secrets that do not contain any client certificates.
+
+If you find that the filters are not having the desired effect, you can enable
+debug logging by setting the log-level to `debug`. This will log info about why
+certain resources are not being gathered.

--- a/examples/machinehub.yaml
+++ b/examples/machinehub.yaml
@@ -28,6 +28,8 @@ data-gatherers:
     - type!=kubernetes.io/dockerconfigjson
     - type!=bootstrap.kubernetes.io/token
     - type!=helm.sh/release.v1
+    filters:
+    - ExcludeTLSSecretsWithoutClientCert
 
 # Gather Kubernetes service accounts
 - name: ark/serviceaccounts

--- a/pkg/datagatherer/k8s/cache.go
+++ b/pkg/datagatherer/k8s/cache.go
@@ -1,11 +1,16 @@
 package k8s
 
 import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pmylund/go-cache"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/jetstack/preflight/api"
@@ -39,9 +44,141 @@ func logCacheUpdateFailure(log logr.Logger, obj interface{}, operation string) {
 	log.Error(err, "Cache update failure", "operation", operation)
 }
 
+// cacheFilterFunction is a function that can be used to filter out objects
+// that should not be added to the cache. If the function returns true, the
+// object is filtered out.
+type cacheFilterFunction func(logr.Logger, interface{}) bool
+
+// excludeTLSSecretsWithoutClientCert filters out all TLS secrets that do not
+// contain a client certificate in the `tls.crt` key.
+// Secrets are obtained by a DynamicClient, so they have type
+// *unstructured.Unstructured.
+func excludeTLSSecretsWithoutClientCert(log logr.Logger, obj interface{}) bool {
+	// Fast path: type assertion and kind/type checks
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		log.V(4).Info("Object is not a Unstructured", "type", fmt.Sprintf("%T", obj))
+		return false
+	}
+	if unstructuredObj.GetKind() != "Secret" || unstructuredObj.GetAPIVersion() != "v1" {
+		return false
+	}
+
+	log = log.WithValues("namespace", unstructuredObj.GetNamespace(), "name", unstructuredObj.GetName())
+
+	secretType, found, err := unstructured.NestedString(unstructuredObj.Object, "type")
+	if err != nil || !found || secretType != string(corev1.SecretTypeTLS) {
+		log.V(4).Info("Object is not a TLS Secret", "type", secretType)
+		return false
+	}
+
+	// Directly extract tls.crt from unstructured data (avoid conversion if possible)
+	dataMap, found, err := unstructured.NestedMap(unstructuredObj.Object, "data")
+	if err != nil || !found {
+		log.V(4).Info("Secret data missing or not a map")
+		return true
+	}
+	tlsCrtRaw, found := dataMap[corev1.TLSCertKey]
+	if !found {
+		log.V(4).Info("TLS Secret does not contain tls.crt key")
+		return true
+	}
+
+	// Decode base64 if necessary (K8s secrets store data as base64-encoded strings)
+	var tlsCrtBytes []byte
+	switch v := tlsCrtRaw.(type) {
+	case string:
+		decoded, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			log.V(4).Info("Failed to decode tls.crt base64", "error", err.Error())
+			return true
+		}
+		tlsCrtBytes = decoded
+	case []byte:
+		tlsCrtBytes = v
+	default:
+		log.V(4).Info("tls.crt is not a string or byte slice", "type", fmt.Sprintf("%T", v))
+		return true
+	}
+
+	// Parse PEM certificate chain
+	certs, err := parsePEMCertificateChain(tlsCrtBytes)
+	if err != nil || len(certs) == 0 {
+		log.V(4).Info("Failed to parse tls.crt as PEM encoded X.509 certificate chain", "error", err.Error())
+		return true
+	}
+
+	// Check if the leaf certificate is a client certificate
+	if isClientCertificate(certs[0]) {
+		log.V(4).Info("TLS Secret contains a client certificate")
+		return false
+	}
+
+	log.V(4).Info("TLS Secret does not contain a client certificate")
+	return true
+}
+
+// isClientCertificate checks if the given certificate is a client certificate
+// by checking if it has the ClientAuth EKU.
+func isClientCertificate(cert *x509.Certificate) bool {
+	if cert == nil {
+		return false
+	}
+	// Check if the certificate has the ClientAuth EKU
+	for _, eku := range cert.ExtKeyUsage {
+		if eku == x509.ExtKeyUsageClientAuth {
+			return true
+		}
+	}
+	return false
+}
+
+// parsePEMCertificateChain parses a PEM encoded certificate chain and returns
+// a slice of x509.Certificate pointers. It returns an error if the data cannot
+// be parsed as a certificate chain.
+// The supplied data can contain multiple PEM blocks, the function will parse
+// all of them and return a slice of certificates.
+func parsePEMCertificateChain(data []byte) ([]*x509.Certificate, error) {
+	// Parse the PEM encoded certificate chain
+	var certs []*x509.Certificate
+	var block *pem.Block
+	rest := data
+	for {
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Bytes) == 0 {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
+		}
+		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates found")
+	}
+	return certs, nil
+}
+
 // onAdd handles the informer creation events, adding the created runtime.Object
 // to the data gatherer's cache. The cache key is the uid of the object
-func onAdd(log logr.Logger, obj interface{}, dgCache *cache.Cache) {
+// The object is wrapped in a GatheredResource struct.
+// If the object is already present in the cache, it gets replaced.
+// The cache key is the uid of the object
+// The supplied filter functions can be used to filter out objects that
+// should not be added to the cache.
+// If multiple filter functions are supplied, the object is filtered out
+// if any of the filter functions returns true.
+func onAdd(log logr.Logger, obj interface{}, dgCache *cache.Cache, filters ...cacheFilterFunction) {
+	for _, filter := range filters {
+		if filter != nil && filter(log, obj) {
+			return
+		}
+	}
+
 	item, ok := obj.(cacheResource)
 	if ok {
 		cacheObject := &api.GatheredResource{


### PR DESCRIPTION
This PR introduces a configurable filter for the k8s-dynamic data gatherer that excludes some Kubernetes TLS secrets; 
those which do not contain a client certificate. 
This is in support of the CyberArk Discovery and Context service which wants various Secret types, but in the case of X.509 certificates, they only need certificates which allow Client Authentication. So in the interests of least privilege we try to only send data that is strictly needed.
 
- Introduce ExcludeTLSSecretsWithoutClientCert filter for k8s-dynamic gatherer
- Update config, docs, and examples to support and demonstrate filter usage
- Implement filter logic to exclude TLS secrets lacking client certificates
- Extend tests to cover filtering of TLS secrets based on certificate EKU
- Add logging for filter decisions and error cases

Part of: https://venafi.atlassian.net/browse/VC-43403

## Testing

Run the agent and watch it log trace messages as you create TLS secrets
```
$ go run ./cmd/ark agent --log-level 2 -c examples/machinehub.yaml --output-path data.json -p 1h
```

```
$ step certificate create foo foo.crt foo.key --profile self-signed --subtle --no-password --insecure
Your certificate has been saved in foo.crt.
Your private key has been saved in foo.key.

$ kubectl create secret  tls foo --key=foo.key --cert foo.crt
secret/foo created
```

```
I0911 22:34:03.464756  162389 cache.go:115] "TLS Secret contains a client certificate" namespace="default" name="foo"
I0911 22:35:08.707640  162389 cache.go:115] "TLS Secret contains a client certificate" namespace="cert-manager" name="foo"
```

Run the agent in --machine-hub mode and use mitmproxy to examine the snapshot that it uploads:

```
mitmproxy
```

```
$ export HTTPS_PROXY=localhost:8080
$ go run ./cmd/ark agent --log-level 2 -c examples/machinehub.yaml --machine-hub --one-shot
```

Export the request (via mitmproxy)

```
$ tail -1 request.txt | jq '.secrets'
```

```json

  {
    "apiVersion": "v1",
    "data": {
      "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJlakNDQVNDZ0F3SUJBZ0lRSWl2YnBPSzZLL1JOWWs5WVRjR0t5akFLQmdncWhrak9QUVFEQWpBT01Rd3cKQ2dZRFZRUURFd05tYjI4d0hoY05NalV3T1RFeE1qRXpNek01V2hjTk1qVXdPVEV5TWpFek16TTVXakFPTVF3dwpDZ1lEVlFRREV3Tm1iMjh3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVNFQnpyN3ozSWphMnJnCis0ODJrbUtCZzhWQUY5MElOQzBqYVM5bFZKbElCS2Zja2NhcDEvbHNKRTdCTm9UMDZVS3hTWng2NUwzWTZGTzYKdkRFeGE4cU5vMkF3WGpBT0JnTlZIUThCQWY4RUJBTUNCNEF3SFFZRFZSMGxCQll3RkFZSUt3WUJCUVVIQXdFRwpDQ3NHQVFVRkJ3TUNNQjBHQTFVZERnUVdCQlRSamxjRFdpaTBNNTQvLzRSVmQ1SERFa3RkTFRBT0JnTlZIUkVFCkJ6QUZnZ05tYjI4d0NnWUlLb1pJemowRUF3SURTQUF3UlFJaEFOazFOckNabk1FMHJlSlROU3NHT3N4aGk2ZnUKZ2paOFd1OG02QURJek9YMkFpQkU0V2gvUFhDdngyR3liZ2ltWVNYWXkxY1RNaFhjbXZ2a2JCbDhObnBEeGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
    },
    "kind": "Secret",
    "metadata": {
      "creationTimestamp": "2025-09-11T21:34:03Z",
      "name": "foo",
      "namespace": "default",
      "resourceVersion": "4618",
      "uid": "11bd6a5e-b79b-4117-ac38-c16cb7f911d9"
    },
    "type": "kubernetes.io/tls"
  }
```