### PR TITLE
[VC-35565] Automate the e2e script to run in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,3 +63,56 @@ jobs:
           key: downloaded-${{ runner.os }}-${{ hashFiles('klone.yaml') }}-test-unit
 
       - run: make -j test-unit test-helm
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/repo_access
+        with:
+          DEPLOY_KEY_READ_VENAFI_CONNECTION_LIB: ${{ secrets.DEPLOY_KEY_READ_VENAFI_CONNECTION_LIB }}
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      - name: Set up gcloud
+        id: setup-gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: machineidentitysecurity-jsci-e
+
+      - name: Configure Docker for Google Artifact Registry
+        run: gcloud auth configure-docker europe-west1-docker.pkg.dev
+
+      - name: Install dependencies
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+          curl -sSfL https://dl.venafi.cloud/venctl/latest/installer.sh | bash
+          echo "/home/runner/.venafi/bin" >> $GITHUB_PATH    
+          curl -LO https://github.com/smallstep/cli/releases/latest/download/step-cli_amd64.deb
+          sudo apt-get install ./step-cli_amd64.deb
+          helm plugin install https://github.com/databus23/helm-diff
+
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go-version.outputs.result }}
+      - run: make -j test-e2e-gke
+        env:
+          VEN_API_KEY: ${{ secrets.VEN_API_KEY_PULL }}
+          VEN_API_KEY_PULL: ${{ secrets.VEN_API_KEY_PULL }}
+          OCI_BASE: europe-west1-docker.pkg.dev/machineidentitysecurity-jsci-e/js-agent-ci-repo
+          VEN_API_HOST: api.venafi.cloud
+          VEN_ZONE: mladen-test\Default
+          VEN_VCP_REGION: us
+          CLOUDSDK_CORE_PROJECT: machineidentitysecurity-jsci-e
+          CLOUDSDK_COMPUTE_ZONE: europe-west1-b
+          CLUSTER_NAME: test-secretless

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,6 +65,7 @@ jobs:
       - run: make -j test-unit test-helm
 
   test-e2e:
+    if: contains(github.event.pull_request.labels.*.name, 'test-e2e')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +75,7 @@ jobs:
       - uses: ./.github/actions/repo_access
         with:
           DEPLOY_KEY_READ_VENAFI_CONNECTION_LIB: ${{ secrets.DEPLOY_KEY_READ_VENAFI_CONNECTION_LIB }}
+
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2
@@ -84,19 +86,11 @@ jobs:
         id: setup-gcloud
         uses: google-github-actions/setup-gcloud@v2
         with:
+          install_components: "gke-gcloud-auth-plugin"
           project_id: machineidentitysecurity-jsci-e
 
       - name: Configure Docker for Google Artifact Registry
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
-
-      - name: Install dependencies
-        run: |
-          gcloud components install gke-gcloud-auth-plugin
-          curl -sSfL https://dl.venafi.cloud/venctl/latest/installer.sh | bash
-          echo "/home/runner/.venafi/bin" >> $GITHUB_PATH    
-          curl -LO https://github.com/smallstep/cli/releases/latest/download/step-cli_amd64.deb
-          sudo apt-get install ./step-cli_amd64.deb
-          helm plugin install https://github.com/databus23/helm-diff
 
       - id: go-version
         run: |
@@ -105,14 +99,40 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go-version.outputs.result }}
-      - run: make -j test-e2e-gke
+
+      - name: Generate timestamp for cluster name
+        id: timestamp # Give the step an ID to reference its output
+        run: |
+          # Generate a timestamp in the format YYMMDD-HHMMSS.
+          # Extracting from PR name would require sanitization due to GKE cluster naming constraints        
+          TIMESTAMP=$(date +'%y%m%d-%H%M%S')
+          CLUSTER_NAME="test-secretless-${TIMESTAMP}"
+          echo "Generated cluster name: ${CLUSTER_NAME}"
+          echo "cluster_name=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
+
+      - run: |
+          make helm-plugins
+          make -j test-e2e-gke
+        # The VEN_API_KEY_PULL secret is set to my API key (Mladen) for glow.in.the.dark tenant.
         env:
           VEN_API_KEY: ${{ secrets.VEN_API_KEY_PULL }}
           VEN_API_KEY_PULL: ${{ secrets.VEN_API_KEY_PULL }}
           OCI_BASE: europe-west1-docker.pkg.dev/machineidentitysecurity-jsci-e/js-agent-ci-repo
           VEN_API_HOST: api.venafi.cloud
-          VEN_ZONE: mladen-test\Default
+          VEN_ZONE: k8s-agent-CI\Default
           VEN_VCP_REGION: us
           CLOUDSDK_CORE_PROJECT: machineidentitysecurity-jsci-e
           CLOUDSDK_COMPUTE_ZONE: europe-west1-b
-          CLUSTER_NAME: test-secretless
+          CLUSTER_NAME: ${{ steps.timestamp.outputs.cluster_name }}
+
+      - name: Delete GKE Cluster
+        # 'always()' - Run this step regardless of success or failure.
+        # '!contains(...)' - AND only run if the list of PR labels DOES NOT contain 'keep-e2e-cluster'.
+        # NOTE: You will have to delete the test cluster manually when finished with debugging or incur costs.
+        if: always() && !contains(github.event.pull_request.labels.*.name, 'keep-e2e-cluster')
+        run: |
+          echo "Label 'keep-e2e-cluster' not found. Cleaning up GKE cluster ${{ steps.timestamp.outputs.cluster_name }}"
+          gcloud container clusters delete ${{ steps.timestamp.outputs.cluster_name }} \
+            --project=${{ secrets.GCP_PROJECT_ID }} \
+            --zone=europe-west1-b \
+            --quiet

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -133,6 +133,6 @@ jobs:
         run: |
           echo "Label 'keep-e2e-cluster' not found. Cleaning up GKE cluster ${{ steps.timestamp.outputs.cluster_name }}"
           gcloud container clusters delete ${{ steps.timestamp.outputs.cluster_name }} \
-            --project=${{ secrets.GCP_PROJECT_ID }} \
+            --project=machineidentitysecurity-jsci-e \
             --zone=europe-west1-b \
             --quiet

--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ The following metrics are collected:
 - Go collector: via the [default registry](https://github.com/prometheus/client_golang/blob/34e02e282dc4a3cb55ca6441b489ec182e654d59/prometheus/registry.go#L60-L63) in Prometheus `client_golang`.
 - Process collector: via the [default registry](https://github.com/prometheus/client_golang/blob/34e02e282dc4a3cb55ca6441b489ec182e654d59/prometheus/registry.go#L60-L63) in Prometheus `client_golang`.
 - Agent metrics: `data_readings_upload_size`: Data readings upload size (in bytes) sent by the in-cluster agent.
+
+## End to end testing
+
+An end to end test script is available in the [./hack/e2e/test.sh](./hack/e2e/test.sh) directory. It is configured to run in CI
+in the tests.yaml GitHub Actions workflow. To run the script you will need to add the `test-e2e` label to the PR.
+The script creates a cluster in GKE and cleanups after itself unless the `keep-e2e-cluster` label is set on the PR. Adding that 
+label will leave the cluster running for further debugging but it will incur costs so manually delete the cluster when done.

--- a/hack/e2e/test.sh
+++ b/hack/e2e/test.sh
@@ -88,9 +88,9 @@ kubectl create ns venafi || true
 # workload identity service account as it doesn't matter.
 if ! kubectl get secret venafi-image-pull-secret -n venafi; then
   venctl iam service-accounts registry create \
-    --api-key "${VEN_API_KEY_PULL}" \
+    --api-key $VEN_API_KEY_PULL \
     --no-prompts \
-    --owning-team "$(curl --fail-with-body -sS "https://${VEN_API_HOST}/v1/teams" -H "tppl-api-key: $VEN_API_KEY_PULL" | jq '.teams[0].id' -r)" \
+    --owning-team "$(curl --fail-with-body -sS "https://${VEN_API_HOST}/v1/teams" -H "tppl-api-key: ${VEN_API_KEY_PULL}" | jq '.teams[0].id' -r)" \
     --name "venafi-kubernetes-agent-e2e-registry-${RANDOM}" \
     --scopes enterprise-cert-manager,enterprise-venafi-issuer,enterprise-approver-policy \
     | jq '{

--- a/hack/e2e/test.sh
+++ b/hack/e2e/test.sh
@@ -26,7 +26,8 @@
 set -o nounset
 set -o errexit
 set -o pipefail
-set -o xtrace
+# Commenting out for CI, uncomment for local debugging
+#set -o xtrace
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 root_dir=$(cd "${script_dir}/../.." && pwd)
@@ -115,6 +116,7 @@ fi
 
 export VENAFI_KUBERNETES_AGENT_CLIENT_ID="not-used-but-required-by-venctl"
 venctl components kubernetes apply \
+  --no-prompts \
   --region $VEN_VCP_REGION \
   --cert-manager \
   --venafi-enhanced-issuer \

--- a/hack/e2e/test.sh
+++ b/hack/e2e/test.sh
@@ -116,7 +116,6 @@ fi
 
 export VENAFI_KUBERNETES_AGENT_CLIENT_ID="not-used-but-required-by-venctl"
 venctl components kubernetes apply \
-  --no-prompts \
   --region $VEN_VCP_REGION \
   --cert-manager \
   --venafi-enhanced-issuer \

--- a/hack/e2e/values.venafi-kubernetes-agent.yaml
+++ b/hack/e2e/values.venafi-kubernetes-agent.yaml
@@ -10,4 +10,4 @@ authentication:
 
 extraArgs:
 - --logging-format=json
-- --log-level=6
+- --log-level=4

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -51,8 +51,8 @@ shared_generate_targets += generate-crds-venconn
 ## Wait for it to log a message indicating successful data upload.
 ## See `hack/e2e/test.sh` for the full test script.
 ## @category Testing
-test-e2e-gke:
-	./hack/e2e/test.sh
+test-e2e-gke: | $(NEEDS_HELM) $(NEEDS_STEP) $(NEEDS_VENCTL)
+	PATH="$(bin_dir)/tools:${PATH}" ./hack/e2e/test.sh
 
 .PHONY: test-helm
 ## Run `helm unittest`.
@@ -66,6 +66,15 @@ test-helm: | $(NEEDS_HELM-UNITTEST)
 test-helm-snapshot: | $(NEEDS_HELM-UNITTEST)
 	$(HELM-UNITTEST) ./deploy/charts/venafi-kubernetes-agent/ -u
 
+.PHONY: helm-plugins
+## Install required helm plugins
+helm-plugins: $(NEEDS_HELM)
+	@if ! $(HELM) plugin list | grep -q diff; then \
+		echo ">>> Installing helm-diff plugin"; \
+		$(HELM) plugin install https://github.com/databus23/helm-diff; \
+	else \
+		echo "helm-diff plugin already installed"; \
+	fi
 
 .PHONY: verify-govulncheck
 ## Verify all Go modules for vulnerabilities using govulncheck Copied from makefile-modules

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -1,5 +1,6 @@
 include make/test-unit.mk
 include make/ark/02_mod.mk
+include make/extra_tools.mk
 
 GITHUB_OUTPUT ?= /dev/stderr
 .PHONY: release

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -52,7 +52,7 @@ shared_generate_targets += generate-crds-venconn
 ## See `hack/e2e/test.sh` for the full test script.
 ## @category Testing
 test-e2e-gke: | $(NEEDS_HELM) $(NEEDS_STEP) $(NEEDS_VENCTL)
-	PATH="$(bin_dir)/tools:${PATH}" ./hack/e2e/test.sh
+	./hack/e2e/test.sh
 
 .PHONY: test-helm
 ## Run `helm unittest`.

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -1,16 +1,4 @@
-# Copyright 2023 The cert-manager Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 
 ifndef bin_dir
 $(error bin_dir is not set)
@@ -636,6 +624,34 @@ $(DOWNLOAD_DIR)/tools/operator-sdk@$(OPERATOR-SDK_VERSION)_$(HOST_OS)_$(HOST_ARC
 		$(checkhash_script) $(outfile) $(operator-sdk_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
 		chmod +x $(outfile)
 
+# https://docs.venafi.cloud/vaas/venctl/c-venctl-releases/
+venctl_linux_amd64_SHA256SUM=26e7b7a7e134f1cf1f3ffacf4ae53ec6849058db5007ce4088d51f404ededb4a
+venctl_darwin_amd64_SHA256SUM=2e76693901abcb2c018f66d3a10558c66ca09d1a3be912258bcd6c58e89aae80
+venctl_darwin_arm64_SHA256SUM=4350912d67683773302655e2a0151320514d1ccf82ee99c895e6780f86b6f031
+
+.PRECIOUS: $(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH)
+$(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
+	@source $(lock_script) $@; \
+		$(CURL) https://dl.venafi.cloud/venctl/$(VENCTL_VERSION)/venctl-$(HOST_OS)-$(HOST_ARCH).zip -o $(outfile).zip; \
+		$(checkhash_script) $(outfile).zip $(venctl_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
+		unzip -p $(outfile).zip venctl > $(outfile); \
+		chmod +x $(outfile); \
+		rm -f $(outfile).zip
+
+# https://github.com/smallstep/cli/releases/
+step_linux_amd64_SHA256SUM=2908f3c7d90181eec430070b231da5c0861e37537bf8e2388d031d3bd6c7b8c6
+step_linux_arm64_SHA256SUM=96636a6cc980d53a98c72aa3b99e04f0b874a733d9ddf43fc6b0f1725f425c37
+step_darwin_amd64_SHA256SUM=f6e9a9078cfc5f559c8213e023df6e8ebf8d9d36ffbd82749a41ee1c40a23623
+step_darwin_arm64_SHA256SUM=b856702ee138a9badbe983e88758c0330907ea4f97e429000334ba038597db5b
+
+.PRECIOUS: $(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH)
+$(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
+	@source $(lock_script) $@; \
+		$(CURL) https://dl.smallstep.com/gh-release/cli/gh-release-header/v$(STEP_VERSION)/step_$(HOST_OS)_$(STEP_VERSION)_$(HOST_ARCH).tar.gz -o $(outfile).tar.gz; \
+		$(checkhash_script) $(outfile).tar.gz $(step_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
+		tar xfO $(outfile).tar.gz step_$(STEP_VERSION)/bin/step > $(outfile); \
+		chmod +x $(outfile); \
+		rm -f $(outfile).tar.gz
 #################
 # Other Targets #
 #################

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -624,34 +624,6 @@ $(DOWNLOAD_DIR)/tools/operator-sdk@$(OPERATOR-SDK_VERSION)_$(HOST_OS)_$(HOST_ARC
 		$(checkhash_script) $(outfile) $(operator-sdk_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
 		chmod +x $(outfile)
 
-# https://docs.venafi.cloud/vaas/venctl/c-venctl-releases/
-venctl_linux_amd64_SHA256SUM=26e7b7a7e134f1cf1f3ffacf4ae53ec6849058db5007ce4088d51f404ededb4a
-venctl_darwin_amd64_SHA256SUM=2e76693901abcb2c018f66d3a10558c66ca09d1a3be912258bcd6c58e89aae80
-venctl_darwin_arm64_SHA256SUM=4350912d67683773302655e2a0151320514d1ccf82ee99c895e6780f86b6f031
-
-.PRECIOUS: $(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH)
-$(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
-	@source $(lock_script) $@; \
-		$(CURL) https://dl.venafi.cloud/venctl/$(VENCTL_VERSION)/venctl-$(HOST_OS)-$(HOST_ARCH).zip -o $(outfile).zip; \
-		$(checkhash_script) $(outfile).zip $(venctl_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
-		unzip -p $(outfile).zip venctl > $(outfile); \
-		chmod +x $(outfile); \
-		rm -f $(outfile).zip
-
-# https://github.com/smallstep/cli/releases/
-step_linux_amd64_SHA256SUM=2908f3c7d90181eec430070b231da5c0861e37537bf8e2388d031d3bd6c7b8c6
-step_linux_arm64_SHA256SUM=96636a6cc980d53a98c72aa3b99e04f0b874a733d9ddf43fc6b0f1725f425c37
-step_darwin_amd64_SHA256SUM=f6e9a9078cfc5f559c8213e023df6e8ebf8d9d36ffbd82749a41ee1c40a23623
-step_darwin_arm64_SHA256SUM=b856702ee138a9badbe983e88758c0330907ea4f97e429000334ba038597db5b
-
-.PRECIOUS: $(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH)
-$(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
-	@source $(lock_script) $@; \
-		$(CURL) https://dl.smallstep.com/gh-release/cli/gh-release-header/v$(STEP_VERSION)/step_$(HOST_OS)_$(STEP_VERSION)_$(HOST_ARCH).tar.gz -o $(outfile).tar.gz; \
-		$(checkhash_script) $(outfile).tar.gz $(step_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
-		tar xfO $(outfile).tar.gz step_$(STEP_VERSION)/bin/step > $(outfile); \
-		chmod +x $(outfile); \
-		rm -f $(outfile).tar.gz
 #################
 # Other Targets #
 #################

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -1,4 +1,16 @@
-
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ifndef bin_dir
 $(error bin_dir is not set)
@@ -624,6 +636,34 @@ $(DOWNLOAD_DIR)/tools/operator-sdk@$(OPERATOR-SDK_VERSION)_$(HOST_OS)_$(HOST_ARC
 		$(checkhash_script) $(outfile) $(operator-sdk_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
 		chmod +x $(outfile)
 
+# https://docs.venafi.cloud/vaas/venctl/c-venctl-releases/
+venctl_linux_amd64_SHA256SUM=26e7b7a7e134f1cf1f3ffacf4ae53ec6849058db5007ce4088d51f404ededb4a
+venctl_darwin_amd64_SHA256SUM=2e76693901abcb2c018f66d3a10558c66ca09d1a3be912258bcd6c58e89aae80
+venctl_darwin_arm64_SHA256SUM=4350912d67683773302655e2a0151320514d1ccf82ee99c895e6780f86b6f031
+
+.PRECIOUS: $(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH)
+$(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
+	@source $(lock_script) $@; \
+		$(CURL) https://dl.venafi.cloud/venctl/$(VENCTL_VERSION)/venctl-$(HOST_OS)-$(HOST_ARCH).zip -o $(outfile).zip; \
+		$(checkhash_script) $(outfile).zip $(venctl_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
+		unzip -p $(outfile).zip venctl > $(outfile); \
+		chmod +x $(outfile); \
+		rm -f $(outfile).zip
+
+# https://github.com/smallstep/cli/releases/
+step_linux_amd64_SHA256SUM=2908f3c7d90181eec430070b231da5c0861e37537bf8e2388d031d3bd6c7b8c6
+step_linux_arm64_SHA256SUM=96636a6cc980d53a98c72aa3b99e04f0b874a733d9ddf43fc6b0f1725f425c37
+step_darwin_amd64_SHA256SUM=f6e9a9078cfc5f559c8213e023df6e8ebf8d9d36ffbd82749a41ee1c40a23623
+step_darwin_arm64_SHA256SUM=b856702ee138a9badbe983e88758c0330907ea4f97e429000334ba038597db5b
+
+.PRECIOUS: $(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH)
+$(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
+	@source $(lock_script) $@; \
+		$(CURL) https://dl.smallstep.com/gh-release/cli/gh-release-header/v$(STEP_VERSION)/step_$(HOST_OS)_$(STEP_VERSION)_$(HOST_ARCH).tar.gz -o $(outfile).tar.gz; \
+		$(checkhash_script) $(outfile).tar.gz $(step_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
+		tar xfO $(outfile).tar.gz step_$(STEP_VERSION)/bin/step > $(outfile); \
+		chmod +x $(outfile); \
+		rm -f $(outfile).tar.gz
 #################
 # Other Targets #
 #################

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -636,34 +636,6 @@ $(DOWNLOAD_DIR)/tools/operator-sdk@$(OPERATOR-SDK_VERSION)_$(HOST_OS)_$(HOST_ARC
 		$(checkhash_script) $(outfile) $(operator-sdk_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
 		chmod +x $(outfile)
 
-# https://docs.venafi.cloud/vaas/venctl/c-venctl-releases/
-venctl_linux_amd64_SHA256SUM=26e7b7a7e134f1cf1f3ffacf4ae53ec6849058db5007ce4088d51f404ededb4a
-venctl_darwin_amd64_SHA256SUM=2e76693901abcb2c018f66d3a10558c66ca09d1a3be912258bcd6c58e89aae80
-venctl_darwin_arm64_SHA256SUM=4350912d67683773302655e2a0151320514d1ccf82ee99c895e6780f86b6f031
-
-.PRECIOUS: $(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH)
-$(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
-	@source $(lock_script) $@; \
-		$(CURL) https://dl.venafi.cloud/venctl/$(VENCTL_VERSION)/venctl-$(HOST_OS)-$(HOST_ARCH).zip -o $(outfile).zip; \
-		$(checkhash_script) $(outfile).zip $(venctl_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
-		unzip -p $(outfile).zip venctl > $(outfile); \
-		chmod +x $(outfile); \
-		rm -f $(outfile).zip
-
-# https://github.com/smallstep/cli/releases/
-step_linux_amd64_SHA256SUM=2908f3c7d90181eec430070b231da5c0861e37537bf8e2388d031d3bd6c7b8c6
-step_linux_arm64_SHA256SUM=96636a6cc980d53a98c72aa3b99e04f0b874a733d9ddf43fc6b0f1725f425c37
-step_darwin_amd64_SHA256SUM=f6e9a9078cfc5f559c8213e023df6e8ebf8d9d36ffbd82749a41ee1c40a23623
-step_darwin_arm64_SHA256SUM=b856702ee138a9badbe983e88758c0330907ea4f97e429000334ba038597db5b
-
-.PRECIOUS: $(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH)
-$(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
-	@source $(lock_script) $@; \
-		$(CURL) https://dl.smallstep.com/gh-release/cli/gh-release-header/v$(STEP_VERSION)/step_$(HOST_OS)_$(STEP_VERSION)_$(HOST_ARCH).tar.gz -o $(outfile).tar.gz; \
-		$(checkhash_script) $(outfile).tar.gz $(step_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
-		tar xfO $(outfile).tar.gz step_$(STEP_VERSION)/bin/step > $(outfile); \
-		chmod +x $(outfile); \
-		rm -f $(outfile).tar.gz
 #################
 # Other Targets #
 #################

--- a/make/extra_tools.mk
+++ b/make/extra_tools.mk
@@ -4,3 +4,6 @@ ADDITIONAL_GO_DEPENDENCIES :=
 # https://pkg.go.dev/github.com/helm-unittest/helm-unittest?tab=versions
 ADDITIONAL_TOOLS += helm-unittest=v0.8.2
 ADDITIONAL_GO_DEPENDENCIES += helm-unittest=github.com/helm-unittest/helm-unittest/cmd/helm-unittest
+
+ADDITIONAL_TOOLS += venctl=1.16.0
+ADDITIONAL_TOOLS += step=0.28.2

--- a/make/extra_tools.mk
+++ b/make/extra_tools.mk
@@ -7,3 +7,32 @@ ADDITIONAL_GO_DEPENDENCIES += helm-unittest=github.com/helm-unittest/helm-unitte
 
 ADDITIONAL_TOOLS += venctl=1.16.0
 ADDITIONAL_TOOLS += step=0.28.2
+
+# https://docs.venafi.cloud/vaas/venctl/c-venctl-releases/
+venctl_linux_amd64_SHA256SUM=26e7b7a7e134f1cf1f3ffacf4ae53ec6849058db5007ce4088d51f404ededb4a
+venctl_darwin_amd64_SHA256SUM=2e76693901abcb2c018f66d3a10558c66ca09d1a3be912258bcd6c58e89aae80
+venctl_darwin_arm64_SHA256SUM=4350912d67683773302655e2a0151320514d1ccf82ee99c895e6780f86b6f031
+
+.PRECIOUS: $(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH)
+$(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
+	@source $(lock_script) $@; \
+		$(CURL) https://dl.venafi.cloud/venctl/$(VENCTL_VERSION)/venctl-$(HOST_OS)-$(HOST_ARCH).zip -o $(outfile).zip; \
+		$(checkhash_script) $(outfile).zip $(venctl_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
+		unzip -p $(outfile).zip venctl > $(outfile); \
+		chmod +x $(outfile); \
+		rm -f $(outfile).zip
+
+# https://github.com/smallstep/cli/releases/
+step_linux_amd64_SHA256SUM=2908f3c7d90181eec430070b231da5c0861e37537bf8e2388d031d3bd6c7b8c6
+step_linux_arm64_SHA256SUM=96636a6cc980d53a98c72aa3b99e04f0b874a733d9ddf43fc6b0f1725f425c37
+step_darwin_amd64_SHA256SUM=f6e9a9078cfc5f559c8213e023df6e8ebf8d9d36ffbd82749a41ee1c40a23623
+step_darwin_arm64_SHA256SUM=b856702ee138a9badbe983e88758c0330907ea4f97e429000334ba038597db5b
+
+.PRECIOUS: $(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH)
+$(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
+	@source $(lock_script) $@; \
+		$(CURL) https://dl.smallstep.com/gh-release/cli/gh-release-header/v$(STEP_VERSION)/step_$(HOST_OS)_$(STEP_VERSION)_$(HOST_ARCH).tar.gz -o $(outfile).tar.gz; \
+		$(checkhash_script) $(outfile).tar.gz $(step_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
+		tar xfO $(outfile).tar.gz step_$(STEP_VERSION)/bin/step > $(outfile); \
+		chmod +x $(outfile); \
+		rm -f $(outfile).tar.gz

--- a/make/extra_tools.mk
+++ b/make/extra_tools.mk
@@ -7,32 +7,3 @@ ADDITIONAL_GO_DEPENDENCIES += helm-unittest=github.com/helm-unittest/helm-unitte
 
 ADDITIONAL_TOOLS += venctl=1.16.0
 ADDITIONAL_TOOLS += step=0.28.2
-
-# https://docs.venafi.cloud/vaas/venctl/c-venctl-releases/
-venctl_linux_amd64_SHA256SUM=26e7b7a7e134f1cf1f3ffacf4ae53ec6849058db5007ce4088d51f404ededb4a
-venctl_darwin_amd64_SHA256SUM=2e76693901abcb2c018f66d3a10558c66ca09d1a3be912258bcd6c58e89aae80
-venctl_darwin_arm64_SHA256SUM=4350912d67683773302655e2a0151320514d1ccf82ee99c895e6780f86b6f031
-
-.PRECIOUS: $(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH)
-$(DOWNLOAD_DIR)/tools/venctl@$(VENCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
-	@source $(lock_script) $@; \
-		$(CURL) https://dl.venafi.cloud/venctl/$(VENCTL_VERSION)/venctl-$(HOST_OS)-$(HOST_ARCH).zip -o $(outfile).zip; \
-		$(checkhash_script) $(outfile).zip $(venctl_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
-		unzip -p $(outfile).zip venctl > $(outfile); \
-		chmod +x $(outfile); \
-		rm -f $(outfile).zip
-
-# https://github.com/smallstep/cli/releases/
-step_linux_amd64_SHA256SUM=2908f3c7d90181eec430070b231da5c0861e37537bf8e2388d031d3bd6c7b8c6
-step_linux_arm64_SHA256SUM=96636a6cc980d53a98c72aa3b99e04f0b874a733d9ddf43fc6b0f1725f425c37
-step_darwin_amd64_SHA256SUM=f6e9a9078cfc5f559c8213e023df6e8ebf8d9d36ffbd82749a41ee1c40a23623
-step_darwin_arm64_SHA256SUM=b856702ee138a9badbe983e88758c0330907ea4f97e429000334ba038597db5b
-
-.PRECIOUS: $(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH)
-$(DOWNLOAD_DIR)/tools/step@$(STEP_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools
-	@source $(lock_script) $@; \
-		$(CURL) https://dl.smallstep.com/gh-release/cli/gh-release-header/v$(STEP_VERSION)/step_$(HOST_OS)_$(STEP_VERSION)_$(HOST_ARCH).tar.gz -o $(outfile).tar.gz; \
-		$(checkhash_script) $(outfile).tar.gz $(step_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
-		tar xfO $(outfile).tar.gz step_$(STEP_VERSION)/bin/step > $(outfile); \
-		chmod +x $(outfile); \
-		rm -f $(outfile).tar.gz


### PR DESCRIPTION
1. Add the test.sh script to be run by the CI
2. Add all dependencies required to execute the script in extra_tools.mk
3. Created a GCP account (via SNOW request) and setup inside it:
  - A service account with manage GKE permissions, Write Image Repository Permissions and the relevant APIs enabled. 
  - A JSON auth key for this account was set as a secret to the CI runner in `GCP_SA_KEY`
  - A repository to push the images which the script builds
4. A valid API key for https://glow-in-the-dark.venafi.cloud/ was set as a CI secret in VEN_API_KEY_PULL
5. A valid VEN_ZONE was configured - mladen-test\Default. If this is not valid test would fail because the certificate request would be ignored.
6. Created two labels: `test-e2e` and `keep-e2e-cluster` - one to trigger the e2e test and the other to keep the cluster alive in GKE for debugging.
7. Reduced log level for cleaner logs. 
  ```
time=2025-09-15T15:56:32.291Z level=DEBUG+3 msg="Request is not applicable for any policy so ignoring" logger=controller-manager/events type=Normal object="{Kind:CertificateRequest Namespace:team-1 Name:app-0-1 UID:12206e29-27b6-4ea4-8171-5c335fc61537 APIVersion:cert-manager.io/v1 ResourceVersion:1757948283819711024 FieldPath:}" reason=Unprocessed
```

Closes https://venafi.atlassian.net/browse/VC-35565