### PR TITLE
[VC-45001] Add telemetry header to all API requests

### DIFF
--- a/internal/cyberark/api/telemetry.go
+++ b/internal/cyberark/api/telemetry.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+
+	"github.com/jetstack/preflight/pkg/version"
+)
+
+// Integrations working with the Identity Security Platform, should add metadata
+// in their API calls, to provide insights into how customers utilize each API.
+//
+// - IntegrationName (in): The vendor integration name (required)
+// - IntegrationType (it): Integration Type	(required)
+// - IntegrationVersion (iv): The plugin version being used (required)
+// - VendorName (vn): Vendor name (required)
+// - VendorVersion (vv): Version of the vendor product in which the plugin is used (if applicable)
+
+const (
+	// TelemetryHeaderKey is the name of the HTTP header to use for telemetry
+	TelemetryHeaderKey = "X-Cybr-Telemetry"
+)
+
+var (
+	telemetryValues       url.Values
+	telemetryValueEncoded string
+)
+
+func init() {
+	telemetryValues = url.Values{}
+	telemetryValues.Set("in", "cyberark-disco-agent")
+	telemetryValues.Set("vn", "CyberArk")
+	telemetryValues.Set("it", "KubernetesAgent")
+	telemetryValues.Set("iv", version.PreflightVersion)
+	telemetryValueEncoded = base64.URLEncoding.EncodeToString([]byte(telemetryValues.Encode()))
+}
+
+// SetTelemetryRequestHeader adds the x-cybr-telemetry header to the given HTTP
+// request, with information about this integration.
+func SetTelemetryRequestHeader(req *http.Request) {
+	req.Header.Set(TelemetryHeaderKey, telemetryValueEncoded)
+}

--- a/internal/cyberark/api/telemetry_test.go
+++ b/internal/cyberark/api/telemetry_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test the SetTelemetryRequestHeader function
+func TestSetTelemetryRequestHeader(t *testing.T) {
+	// Create a new HTTP request
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err, "failed to create HTTP request")
+
+	// Call the function to set the telemetry header
+	SetTelemetryRequestHeader(req)
+
+	base64Value := req.Header.Get(TelemetryHeaderKey)
+	// Check that the header is set
+	require.NotEmpty(t, base64Value, "telemetry header should be set")
+
+	queryString, err := base64.URLEncoding.DecodeString(base64Value)
+	require.NoError(t, err, "failed to decode telemetry header value")
+
+	values, err := url.ParseQuery(string(queryString))
+	require.NoError(t, err, "failed to parse telemetry header value")
+	require.Equal(t, telemetryValues, values, "telemetry header value should match expected values")
+}

--- a/internal/cyberark/dataupload/dataupload.go
+++ b/internal/cyberark/dataupload/dataupload.go
@@ -14,6 +14,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
+	arkapi "github.com/jetstack/preflight/internal/cyberark/api"
 	"github.com/jetstack/preflight/pkg/version"
 )
 
@@ -167,6 +168,9 @@ func (c *CyberArkClient) retrievePresignedUploadURL(ctx context.Context, checksu
 		return "", fmt.Errorf("failed to authenticate request: %s", err)
 	}
 	version.SetUserAgent(req)
+
+	// Add telemetry headers
+	arkapi.SetTelemetryRequestHeader(req)
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/cyberark/dataupload/mock.go
+++ b/internal/cyberark/dataupload/mock.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/transport"
 
+	arkapi "github.com/jetstack/preflight/internal/cyberark/api"
 	"github.com/jetstack/preflight/pkg/version"
 )
 
@@ -79,6 +80,12 @@ func (mds *mockDataUploadServer) handleSnapshotLinks(w http.ResponseWriter, r *h
 
 	if r.Header.Get("User-Agent") != version.UserAgent() {
 		http.Error(w, "should set user agent on all requests", http.StatusInternalServerError)
+		return
+	}
+
+	if r.Header.Get(arkapi.TelemetryHeaderKey) == "" {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("should set telemetry header on all requests"))
 		return
 	}
 
@@ -156,6 +163,12 @@ func (mds *mockDataUploadServer) handlePresignedUpload(w http.ResponseWriter, r 
 
 	if r.Header.Get("User-Agent") != version.UserAgent() {
 		http.Error(w, "should set user agent on all requests", http.StatusInternalServerError)
+		return
+	}
+
+	if r.Header.Get(arkapi.TelemetryHeaderKey) != "" {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("should NOT set telemetry header on requests to presigned URL"))
 		return
 	}
 

--- a/internal/cyberark/identity/identity.go
+++ b/internal/cyberark/identity/identity.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	arkapi "github.com/jetstack/preflight/internal/cyberark/api"
 	"github.com/jetstack/preflight/pkg/logs"
 	"github.com/jetstack/preflight/pkg/version"
 )
@@ -422,4 +423,6 @@ func setIdentityHeaders(r *http.Request) {
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("X-IDAP-NATIVE-CLIENT", "true") //nolint: canonicalheader
 	version.SetUserAgent(r)
+	// Add telemetry headers
+	arkapi.SetTelemetryRequestHeader(r)
 }

--- a/internal/cyberark/servicediscovery/discovery.go
+++ b/internal/cyberark/servicediscovery/discovery.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 
+	arkapi "github.com/jetstack/preflight/internal/cyberark/api"
 	"github.com/jetstack/preflight/pkg/version"
 )
 
@@ -109,7 +110,8 @@ func (c *Client) DiscoverServices(ctx context.Context, subdomain string) (*Servi
 
 	request.Header.Set("Accept", "application/json")
 	version.SetUserAgent(request)
-
+	// Add telemetry headers
+	arkapi.SetTelemetryRequestHeader(request)
 	resp, err := c.client.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to perform HTTP request: %s", err)

--- a/internal/cyberark/servicediscovery/mock.go
+++ b/internal/cyberark/servicediscovery/mock.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/client-go/transport"
 
+	arkapi "github.com/jetstack/preflight/internal/cyberark/api"
 	"github.com/jetstack/preflight/pkg/version"
 
 	_ "embed"
@@ -89,6 +90,12 @@ func (mds *mockDiscoveryServer) ServeHTTP(w http.ResponseWriter, r *http.Request
 	if r.Header.Get("User-Agent") != version.UserAgent() {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("should set user agent on all requests"))
+		return
+	}
+
+	if r.Header.Get(arkapi.TelemetryHeaderKey) == "" {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("should set telemetry header on all requests"))
 		return
 	}
 


### PR DESCRIPTION
The CyberArk APIs are going to require clients to supply this telemetry header. There's more information in the JIRA issue and in teams.

Fixes: https://venafi.atlassian.net/browse/VC-45001

- Introduce SetTelemetryRequestHeader to set X-Cybr-Telemetry header
- Add telemetry header to dataupload, identity, and servicediscovery requests
- Update mocks to validate presence or absence of telemetry header as appropriate
- Add tests for telemetry header encoding and correctness
