### PR TITLE
[VC-45025] cyberark-disco-agent: Change default config.period to 12h in values.yaml

### DIFF
--- a/deploy/charts/cyberark-disco-agent/README.md
+++ b/deploy/charts/cyberark-disco-agent/README.md
@@ -257,10 +257,10 @@ Configure a PodDisruptionBudget for the agent's Deployment. If running with mult
 #### **config.period** ~ `string`
 > Default value:
 > ```yaml
-> 1h0m0s
+> 12h0m0s
 > ```
 
-Push data every hour unless changed.
+Push data every 12 hours unless changed.
 #### **config.excludeAnnotationKeysRegex** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/cyberark-disco-agent/tests/README.md
+++ b/deploy/charts/cyberark-disco-agent/tests/README.md
@@ -1,0 +1,9 @@
+# `helm unittest`
+
+We use `helm unittest` to test the YAML output coming out of the Helm chart.
+
+In order to update the snapshots, run the following command:
+
+```bash
+make test-helm-snapshot
+```

--- a/deploy/charts/cyberark-disco-agent/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deploy/charts/cyberark-disco-agent/tests/__snapshot__/configmap_test.yaml.snap
@@ -1,0 +1,210 @@
+custom-period:
+  1: |
+    apiVersion: v1
+    data:
+      config.yaml: |-
+        period: "1m"
+        data-gatherers:
+        - kind: k8s-discovery
+          name: ark/discovery
+        - kind: k8s-dynamic
+          name: ark/secrets
+          config:
+            resource-type:
+              version: v1
+              resource: secrets
+            field-selectors:
+            - type!=kubernetes.io/dockercfg
+            - type!=kubernetes.io/dockerconfigjson
+            - type!=bootstrap.kubernetes.io/token
+            - type!=helm.sh/release.v1
+        - kind: k8s-dynamic
+          name: ark/serviceaccounts
+          config:
+            resource-type:
+              resource: serviceaccounts
+              version: v1
+        - kind: k8s-dynamic
+          name: ark/roles
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: roles
+        - kind: k8s-dynamic
+          name: ark/clusterroles
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: clusterroles
+        - kind: k8s-dynamic
+          name: ark/rolebindings
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: rolebindings
+        - kind: k8s-dynamic
+          name: ark/clusterrolebindings
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: clusterrolebindings
+        - kind: k8s-dynamic
+          name: ark/jobs
+          config:
+            resource-type:
+              version: v1
+              group: batch
+              resource: jobs
+        - kind: k8s-dynamic
+          name: ark/cronjobs
+          config:
+            resource-type:
+              version: v1
+              group: batch
+              resource: cronjobs
+        - kind: k8s-dynamic
+          name: ark/deployments
+          config:
+            resource-type:
+              version: v1
+              group: apps
+              resource: deployments
+        - kind: k8s-dynamic
+          name: ark/statefulsets
+          config:
+            resource-type:
+              version: v1
+              group: apps
+              resource: statefulsets
+        - kind: k8s-dynamic
+          name: ark/daemonsets
+          config:
+            resource-type:
+              version: v1
+              group: apps
+              resource: daemonsets
+        - kind: k8s-dynamic
+          name: ark/pods
+          config:
+            resource-type:
+              version: v1
+              resource: pods
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cyberark-disco-agent
+        app.kubernetes.io/version: v0.0.0
+        helm.sh/chart: cyberark-disco-agent-0.0.0
+      name: test-cyberark-disco-agent-config
+      namespace: test-ns
+defaults:
+  1: |
+    apiVersion: v1
+    data:
+      config.yaml: |-
+        period: "12h0m0s"
+        data-gatherers:
+        - kind: k8s-discovery
+          name: ark/discovery
+        - kind: k8s-dynamic
+          name: ark/secrets
+          config:
+            resource-type:
+              version: v1
+              resource: secrets
+            field-selectors:
+            - type!=kubernetes.io/dockercfg
+            - type!=kubernetes.io/dockerconfigjson
+            - type!=bootstrap.kubernetes.io/token
+            - type!=helm.sh/release.v1
+        - kind: k8s-dynamic
+          name: ark/serviceaccounts
+          config:
+            resource-type:
+              resource: serviceaccounts
+              version: v1
+        - kind: k8s-dynamic
+          name: ark/roles
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: roles
+        - kind: k8s-dynamic
+          name: ark/clusterroles
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: clusterroles
+        - kind: k8s-dynamic
+          name: ark/rolebindings
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: rolebindings
+        - kind: k8s-dynamic
+          name: ark/clusterrolebindings
+          config:
+            resource-type:
+              version: v1
+              group: rbac.authorization.k8s.io
+              resource: clusterrolebindings
+        - kind: k8s-dynamic
+          name: ark/jobs
+          config:
+            resource-type:
+              version: v1
+              group: batch
+              resource: jobs
+        - kind: k8s-dynamic
+          name: ark/cronjobs
+          config:
+            resource-type:
+              version: v1
+              group: batch
+              resource: cronjobs
+        - kind: k8s-dynamic
+          name: ark/deployments
+          config:
+            resource-type:
+              version: v1
+              group: apps
+              resource: deployments
+        - kind: k8s-dynamic
+          name: ark/statefulsets
+          config:
+            resource-type:
+              version: v1
+              group: apps
+              resource: statefulsets
+        - kind: k8s-dynamic
+          name: ark/daemonsets
+          config:
+            resource-type:
+              version: v1
+              group: apps
+              resource: daemonsets
+        - kind: k8s-dynamic
+          name: ark/pods
+          config:
+            resource-type:
+              version: v1
+              resource: pods
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cyberark-disco-agent
+        app.kubernetes.io/version: v0.0.0
+        helm.sh/chart: cyberark-disco-agent-0.0.0
+      name: test-cyberark-disco-agent-config
+      namespace: test-ns

--- a/deploy/charts/cyberark-disco-agent/tests/configmap_test.yaml
+++ b/deploy/charts/cyberark-disco-agent/tests/configmap_test.yaml
@@ -1,0 +1,16 @@
+suite: test the contents of the config.yaml
+templates:
+  - configmap.yaml
+release:
+  name: test
+  namespace: test-ns
+tests:
+  - it: defaults
+    asserts:
+      - matchSnapshot: {}
+
+  - it: custom-period
+    set:
+      config.period: 1m
+    asserts:
+      - matchSnapshot: {}

--- a/deploy/charts/cyberark-disco-agent/values.schema.json
+++ b/deploy/charts/cyberark-disco-agent/values.schema.json
@@ -128,8 +128,8 @@
       "type": "array"
     },
     "helm-values.config.period": {
-      "default": "1h0m0s",
-      "description": "Push data every hour unless changed.",
+      "default": "12h0m0s",
+      "description": "Push data every 12 hours unless changed.",
       "type": "string"
     },
     "helm-values.extraArgs": {

--- a/deploy/charts/cyberark-disco-agent/values.yaml
+++ b/deploy/charts/cyberark-disco-agent/values.yaml
@@ -122,8 +122,8 @@ podDisruptionBudget:
 
 # Configuration for the agent
 config:
-  # Push data every hour unless changed.
-  period: "1h0m0s"
+  # Push data every 12 hours unless changed.
+  period: "12h0m0s"
 
   # You can configure the agent to exclude some annotations or
   # labels from being pushed . All Kubernetes objects

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -58,13 +58,13 @@ test-e2e-gke: | $(NEEDS_HELM) $(NEEDS_STEP) $(NEEDS_VENCTL)
 ## Run `helm unittest`.
 ## @category Testing
 test-helm: | $(NEEDS_HELM-UNITTEST)
-	$(HELM-UNITTEST) ./deploy/charts/venafi-kubernetes-agent/
+	$(HELM-UNITTEST) ./deploy/charts/{venafi-kubernetes-agent,cyberark-disco-agent}
 
 .PHONY: test-helm-snapshot
 ## Update the `helm unittest` snapshots.
 ## @category Testing
 test-helm-snapshot: | $(NEEDS_HELM-UNITTEST)
-	$(HELM-UNITTEST) ./deploy/charts/venafi-kubernetes-agent/ -u
+	$(HELM-UNITTEST) ./deploy/charts/{venafi-kubernetes-agent,cyberark-disco-agent} -u
 
 .PHONY: helm-plugins
 ## Install required helm plugins

--- a/make/ark/02_mod.mk
+++ b/make/ark/02_mod.mk
@@ -1,19 +1,3 @@
-.PHONY: ark-generate-helm-docs
-## Generate Helm chart documentation.
-## @category CyberArk Discovery and Context
-ark-generate-helm-docs: helm_chart_source_dir := deploy/charts/cyberark-disco-agent
-ark-generate-helm-docs: generate-helm-docs
-
-shared_generate_targets += ark-generate-helm-docs
-
-.PHONY: ark-generate-helm-schema
-## Generate Helm chart schema.
-## @category CyberArk Discovery and Context
-ark-generate-helm-schema: helm_chart_source_dir := deploy/charts/cyberark-disco-agent
-ark-generate-helm-schema: generate-helm-schema
-
-shared_generate_targets += ark-generate-helm-schema
-
 GITHUB_OUTPUT ?= /dev/stderr
 .PHONY: ark-release
 ## Publish all release artifacts (image + helm chart)
@@ -61,3 +45,13 @@ ark-verify:
 		helm_chart_image_name=$(OCI_BASE)/charts/cyberark-disco-agent
 
 shared_verify_targets_dirty += ark-verify
+
+.PHONY: ark-generate
+## Generate Helm chart documentation and schema
+## @category CyberArk Discovery and Context
+ark-generate:
+	$(MAKE) generate-helm-docs generate-helm-schema \
+		helm_chart_source_dir=deploy/charts/cyberark-disco-agent
+
+shared_generate_targets += ark-generate
+


### PR DESCRIPTION
The original project design calls for the agent to upload data every 12 hours.

There is some background information about the 12h interval in the JIRA ticket:
 * https://venafi.atlassian.net/browse/VC-45025

- Add helm unittest test suite and snapshots for configmap.yaml
- Update default config.period to 12h0m0s in values.yaml
- Extend make targets to run helm unittest for cyberark-disco-agent
- Document helm unittest usage and snapshot update steps
- Fix `make generate` so that it also invokes the ark-generate- targets
