### PR TITLE
Bump Github Actions 

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write # needed for keyless signing & google auth
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/repo_access
         with:
@@ -32,7 +32,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 
@@ -41,7 +41,7 @@ jobs:
       id-token: write # needed for google auth
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 
@@ -68,7 +68,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'test-e2e')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -78,13 +78,13 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: Set up gcloud
         id: setup-gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           install_components: "gke-gcloud-auth-plugin"
           project_id: machineidentitysecurity-jsci-e
@@ -96,7 +96,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 


### PR DESCRIPTION
Dependabot updated all the actions in #718 
I reverted the changes to makefile-modules controlled renovate actions so that `make verify` will pass.

Bumps the all-gh-actions group with 5 updates:

| Package | From | To |
| --- | --- | --- |
| [actions/checkout](https://github.com/actions/checkout) | `4` | `5` | | [actions/setup-go](https://github.com/actions/setup-go) | `5` | `6` | | [renovatebot/github-action](https://github.com/renovatebot/github-action) | `43.0.10` | `43.0.12` | | [google-github-actions/auth](https://github.com/google-github-actions/auth) | `2` | `3` | | [google-github-actions/setup-gcloud](https://github.com/google-github-actions/setup-gcloud) | `2` | `3` |

Updates `actions/checkout` from 4 to 5
- [Release notes](https://github.com/actions/checkout/releases)
- [Commits](https://github.com/actions/checkout/compare/v4...v5)

Updates `actions/setup-go` from 5 to 6
- [Release notes](https://github.com/actions/setup-go/releases)
- [Commits](https://github.com/actions/setup-go/compare/v5...v6)

Updates `google-github-actions/auth` from 2 to 3
- [Release notes](https://github.com/google-github-actions/auth/releases)
- [Changelog](https://github.com/google-github-actions/auth/blob/main/CHANGELOG.md)
- [Commits](https://github.com/google-github-actions/auth/compare/v2...v3)

Updates `google-github-actions/setup-gcloud` from 2 to 3
- [Release notes](https://github.com/google-github-actions/setup-gcloud/releases)
- [Changelog](https://github.com/google-github-actions/setup-gcloud/blob/main/CHANGELOG.md)
- [Commits](https://github.com/google-github-actions/setup-gcloud/compare/v2...v3)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-version: '5' dependency-type: direct:production update-type: version-update:semver-major dependency-group: all-gh-actions
- dependency-name: actions/setup-go dependency-version: '6' dependency-type: direct:production update-type: version-update:semver-major dependency-group: all-gh-actions
- dependency-name: renovatebot/github-action dependency-version: 43.0.12 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-gh-actions
- dependency-name: google-github-actions/auth dependency-version: '3' dependency-type: direct:production update-type: version-update:semver-major dependency-group: all-gh-actions
- dependency-name: google-github-actions/setup-gcloud dependency-version: '3' dependency-type: direct:production update-type: version-update:semver-major dependency-group: all-gh-actions ...