### PR TITLE
[VC-45081] Automate the release process for cyberark-disco-agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,19 @@ jobs:
           go-version: ${{ steps.go-version.outputs.result }}
 
       - id: release
-        run: make release
+        run: make release ark-release
 
     outputs:
       RELEASE_OCI_PREFLIGHT_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_PREFLIGHT_IMAGE }}
       RELEASE_OCI_PREFLIGHT_TAG: ${{ steps.release.outputs.RELEASE_OCI_PREFLIGHT_TAG }}
       RELEASE_HELM_CHART_IMAGE: ${{ steps.release.outputs.RELEASE_HELM_CHART_IMAGE }}
       RELEASE_HELM_CHART_VERSION: ${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}
+      ARK_IMAGE: ${{ steps.release.outputs.ARK_IMAGE }}
+      ARK_IMAGE_TAG: ${{ steps.release.outputs.ARK_IMAGE_TAG }}
+      ARK_IMAGE_DIGEST: ${{ steps.release.outputs.ARK_IMAGE_DIGEST }}
+      ARK_CHART: ${{ steps.release.outputs.ARK_CHART }}
+      ARK_CHART_TAG: ${{ steps.release.outputs.ARK_CHART_TAG }}
+      ARK_CHART_DIGEST: ${{ steps.release.outputs.ARK_CHART_DIGEST }}
 
   github_release:
     runs-on: ubuntu-latest
@@ -61,6 +67,12 @@ jobs:
           echo "OCI_PREFLIGHT_TAG: ${{ needs.build_and_push.outputs.RELEASE_OCI_PREFLIGHT_TAG }}" >> .notes-file
           echo "HELM_CHART_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_IMAGE }}" >> .notes-file
           echo "HELM_CHART_VERSION: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
+          echo "ARK_IMAGE: ${{ needs.build_and_push.outputs.ARK_IMAGE }}" >> .notes-file
+          echo "ARK_IMAGE_TAG: ${{ needs.build_and_push.outputs.ARK_IMAGE_TAG }}" >> .notes-file
+          echo "ARK_IMAGE_DIGEST: ${{ needs.build_and_push.outputs.ARK_IMAGE_DIGEST }}" >> .notes-file
+          echo "ARK_CHART: ${{ needs.build_and_push.outputs.ARK_CHART }}" >> .notes-file
+          echo "ARK_CHART_TAG: ${{ needs.build_and_push.outputs.ARK_CHART_TAG }}" >> .notes-file
+          echo "ARK_CHART_DIGEST: ${{ needs.build_and_push.outputs.ARK_CHART_DIGEST }}" >> .notes-file
 
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,10 +10,11 @@ The release process is semi-automated.
 > [!NOTE]
 >
 > Upon pushing the tag, a GitHub Action will do the following:
-> - Build and publish the container image at `quay.io/jetstack/venafi-agent`,
-> - Build and publish the Helm chart at `oci://quay.io/jetstack/charts/venafi-kubernetes-agent`,
+> - Build and publish the container image: `quay.io/jetstack/venafi-agent`,
+> - Build and publish the Helm chart: `oci://quay.io/jetstack/charts/venafi-kubernetes-agent`,
+> - Build and publish the container image: `quay.io/jetstack/cyberark-disco-agent`,
+> - Build and publish the Helm chart: `oci://quay.io/jetstack/charts/cyberark-disco-agent`,
 > - Create a draft GitHub release,
-> - Upload the Helm chart tarball to the GitHub release.
 
 1. Upgrade the Go dependencies.
 
@@ -71,9 +72,10 @@ The release process is semi-automated.
 
 For context, the new tag will create the following images:
 
-| Image                                                     | Automation                                                                                                                                                                                              |
-| --------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Image                                                     | Automation                                                                                   |
+|-----------------------------------------------------------|----------------------------------------------------------------------------------------------|
 | `quay.io/jetstack/venafi-agent`                           | Automatically built by the [release action](.github/workflows/release.yml) on Git tag pushes |
+| `quay.io/jetstack/cyberark-disco-agent`                   | Automatically built by the [release action](.github/workflows/release.yml) on Git tag pushes |
 | `registry.venafi.cloud/venafi-agent/venafi-agent`         | Automatically mirrored by Harbor Replication rule                                            |
 | `private-registry.venafi.cloud/venafi-agent/venafi-agent` | Automatically mirrored by Harbor Replication rule                                            |
 | `private-registry.venafi.eu/venafi-agent/venafi-agent`    | Automatically mirrored by Harbor Replication rule                                            |
@@ -81,8 +83,9 @@ For context, the new tag will create the following images:
 and the following OCI Helm charts:
 
 | Helm Chart                                                           | Automation                                                                                   |
-| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
 | `oci://quay.io/jetstack/charts/venafi-kubernetes-agent`              | Automatically built by the [release action](.github/workflows/release.yml) on Git tag pushes |
+| `oci://quay.io/jetstack/charts/cyberark-disco-agent`                 | Automatically built by the [release action](.github/workflows/release.yml) on Git tag pushes |
 | `oci://registry.venafi.cloud/charts/venafi-kubernetes-agent`         | Automatically mirrored by Harbor Replication rule                                            |
 | `oci://private-registry.venafi.cloud/charts/venafi-kubernetes-agent` | Automatically mirrored by Harbor Replication rule                                            |
 | `oci://private-registry.venafi.eu/charts/venafi-kubernetes-agent`    | Automatically mirrored by Harbor Replication rule                                            |
@@ -118,3 +121,7 @@ v1.1.0 (Git tag in the jetstack-secure repo)
 ### Step 2: Test the Helm chart "venafi-kubernetes-agent" with venctl connect
 
 NOTE(mael): TBD
+
+### Step 3: Test the Helm chart "cyberark-disco-agent"
+
+NOTE(wallrj): TBD

--- a/hack/ark/test-e2e.sh
+++ b/hack/ark/test-e2e.sh
@@ -43,7 +43,11 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 
 pushd "${tmp_dir}"
 > release.env
-make -C "$root_dir" ark-release GITHUB_OUTPUT="${tmp_dir}/release.env"
+make -C "$root_dir" ark-release \
+     GITHUB_OUTPUT="${tmp_dir}/release.env" \
+     OCI_SIGN_ON_PUSH=false \
+     oci_platforms="" \
+     ARK_OCI_BASE="${OCI_BASE}"
 cat release.env
 source release.env
 
@@ -61,15 +65,15 @@ kubectl create secret generic agent-credentials \
         --from-literal=ARK_SUBDOMAIN=$ARK_SUBDOMAIN \
         --from-literal=ARK_DISCOVERY_API=$ARK_DISCOVERY_API
 
-helm upgrade agent "oci://${RELEASE_OCI_CHART}@${RELEASE_OCI_CHART_DIGEST}" \
-     --version "${RELEASE_OCI_CHART_TAG}" \
+helm upgrade agent "oci://${ARK_CHART}@${ARK_CHART_DIGEST}" \
+     --version "${ARK_CHART_TAG}" \
      --install \
      --wait \
      --create-namespace \
      --namespace "$NAMESPACE" \
      --set pprof.enabled=true \
      --set fullnameOverride=disco-agent \
-     --set "image.digest=${RELEASE_OCI_IMAGE_DIGEST}" \
+     --set "image.digest=${ARK_IMAGE_DIGEST}" \
      --set-json "podLabels={\"disco-agent.cyberark.cloud/test-id\": \"${RANDOM}\"}"
 
 kubectl rollout status deployments/disco-agent --namespace "${NAMESPACE}"

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -6,8 +6,6 @@ repo_name := github.com/jetstack/jetstack-secure
 # third-party modules.
 generate-golangci-lint-config: repo_name := github.com/jetstack/preflight
 
-OCI_BASE ?= # default to an empty value to avoid warnings
-
 license_ignore := gitlab.com/venafi,github.com/jetstack
 
 kind_cluster_name := preflight

--- a/make/ark/00_mod.mk
+++ b/make/ark/00_mod.mk
@@ -7,20 +7,20 @@ go_ark_ldflags := \
 	-X $(repo_name)/pkg/version.BuildDate=$(shell date "+%F-%T-%Z") \
 
 oci_ark_base_image_flavor := static
-oci_ark_image_name := quay.io/jetstack/ark-agent
+oci_ark_image_name := quay.io/jetstack/cyberark-disco-agent
 oci_ark_image_tag := $(VERSION)
-oci_ark_image_name_development := jetstack.local/ark-agent
+oci_ark_image_name_development := jetstack.local/cyberark-disco-agent
 
 # Annotations are the standardised set of annotations we set on every component we publish
 oci_ark_build_args := \
 	--image-annotation="org.opencontainers.image.source"="https://github.com/jetstack/jetstack-secure" \
 	--image-annotation="org.opencontainers.image.vendor"="CyberArk Software Ltd." \
 	--image-annotation="org.opencontainers.image.licenses"="EULA - https://www.cyberark.com/contract-terms/" \
-	--image-annotation="org.opencontainers.image.authors"="TODO" \
+	--image-annotation="org.opencontainers.image.authors"="CyberArk Software Ltd." \
 	--image-annotation="org.opencontainers.image.title"="CyberArk Discovery and Context Agent" \
 	--image-annotation="org.opencontainers.image.description"="Gathers machine identity data from Kubernetes clusters." \
-	--image-annotation="org.opencontainers.image.url"="TODO" \
-	--image-annotation="org.opencontainers.image.documentation"="TODO" \
+	--image-annotation="org.opencontainers.image.url"="https://www.cyberark.com/products/" \
+	--image-annotation="org.opencontainers.image.documentation"="https://docs.cyberark.com" \
 	--image-annotation="org.opencontainers.image.version"="$(VERSION)" \
 	--image-annotation="org.opencontainers.image.revision"="$(GITCOMMIT)"
 


### PR DESCRIPTION
This update refactors the release process for the CyberArk Discovery and Context Agent, improving GitHub Actions integration, Makefile variable clarity, and branding/documentation for published images and charts.

Summary of Changes

-   **GitHub Actions**:
    -   Adds ARK image and chart outputs to the release workflow.
    -   Outputs ARK image/chart details (name, tag, digest) for use in downstream jobs.
    -   Updates release notes generation to include ARK artifacts.

-   **Makefile Refactor**:
    -   Removes unused `OCI_BASE` variable from the root Makefile.
    -   Introduces `ARK_OCI_BASE`, `ARK_IMAGE`, and `ARK_CHART` variables for clarity and flexibility.
    -   Refactors image/chart names to use CyberArk branding (e.g., `quay.io/jetstack/cyberark-disco-agent`).
    -   Updates image annotations for vendor, authors, documentation, and product URLs.
    -   Ensures all release outputs are clearly named and accessible for CI/CD.

-   **E2E Test Script**:
    -   Updates to use new ARK image/chart variables.
    -   Ensures correct image/chart is deployed and tested in the e2e workflow.

## Testing 

Installed the released chart, as follows:

```bash
kind create cluster

export NAMESPACE=cyberark
export ARK_CHART=quay.io/jetstack/charts/cyberark-disco-agent

kubectl create ns "$NAMESPACE"

kubectl create secret generic agent-credentials \
        --namespace "$NAMESPACE" \
        --from-literal=ARK_USERNAME=$ARK_USERNAME \
        --from-literal=ARK_SECRET=$ARK_SECRET \
        --from-literal=ARK_SUBDOMAIN=$ARK_SUBDOMAIN \
        --from-literal=ARK_DISCOVERY_API=$ARK_DISCOVERY_API

helm upgrade agent "oci://${ARK_CHART}" \
     --debug \
     --devel \
     --install \
     --wait \
     --namespace "$NAMESPACE" \
     --set fullnameOverride=disco-agent

```

```
NOTES:
CHART NAME: cyberark-disco-agent
CHART VERSION: v1.7.0-alpha.1
APP VERSION: v1.7.0-alpha.1

- Check the application is running:
> kubectl get pods -n cyberark -l app.kubernetes.io/instance=agent

- Check the application logs for successful connection to the platform:
> kubectl logs -n cyberark -l app.kubernetes.io/instance=agent
```

```
$ kubectl logs -n cyberark -l app.kubernetes.io/instance=agent
{"ts":1758291401575.219,"caller":"agent/run.go:58","msg":"Starting","v":0,"logger":"Run","version":"development","commit":""}
{"ts":1758291401576.951,"caller":"agent/config.go:591","msg":"Using period from config","v":0,"logger":"Run","period":"12h0m0s"}
{"ts":1758291401577.008,"caller":"agent/run.go:107","msg":"Metrics endpoints enabled","v":0,"logger":"Run.APIServer","addr":":8081","path":"/metrics"}
{"ts":1758291401577.344,"caller":"agent/run.go:116","msg":"Healthz endpoints enabled","v":0,"logger":"Run.APIServer","addr":":8081","path":"/healthz"}
{"ts":1758291401577.3738,"caller":"agent/run.go:120","msg":"Readyz endpoints enabled","v":0,"logger":"Run.APIServer","addr":":8081","path":"/readyz"}
{"ts":1758291402828.249,"caller":"identity/identity.go:403","msg":"successfully completed AdvanceAuthentication request to CyberArk Identity; login complete","v":0,"logger":"Run.gatherAndOutputData.postData","username":"github-jetstack-secure-tests@cyberark.cloud.420375"}
{"ts":1758291426781.4143,"caller":"agent/run.go:334","msg":"Warning: PushingErr: retrying","v":0,"logger":"Run.gatherAndOutputData","in":"20.147492982s","reason":"post to server failed: while uploading snapshot: while retrieving snapshot upload URL: received response with status code 502: {\"message\": \"Internal server error\"}"}
{"ts":1758291447681.048,"caller":"identity/identity.go:403","msg":"successfully completed AdvanceAuthentication request to CyberArk Identity; login complete","v":0,"logger":"Run.gatherAndOutputData.postData","username":"github-jetstack-secure-tests@cyberark.cloud.420375"}
{"ts":1758291464540.994,"caller":"agent/run.go:334","msg":"Warning: PushingErr: retrying","v":0,"logger":"Run.gatherAndOutputData","in":"31.70021123s","reason":"post to server failed: while uploading snapshot: while retrieving snapshot upload URL: received response with status code 502: {\"message\": \"Internal server error\"}"}
{"ts":1758291496997.672,"caller":"identity/identity.go:403","msg":"successfully completed AdvanceAuthentication request to CyberArk Identity; login complete","v":0,"logger":"Run.gatherAndOutputData.postData","username":"github-jetstack-secure-tests@cyberark.cloud.420375"}
```

> ℹ️ There's a problem with our test tenant which prevents the snapshot upload, but you can see that the agent deployed and attempts the upload.

I also ran the `make ark-test-e2e` target manually. It fails with timeout because of ☝️ that problem with the test tenant, but at least it deploys the agent and attempts to upload:

```
make ark-test-e2e
...
# ... output elided ...
# Readyz endpoints enabled
# Authentication succeeded
# Warning: PushingErr: retrying (502 Internal server error)
# Authentication succeeded
# Warning: PushingErr: retrying (502 Internal server error)
make: *** [ark-test-e2e] Error 124

```