### PR TITLE
add explicit permissions for ESO resources

### DIFF
--- a/deploy/charts/disco-agent/templates/rbac.yaml
+++ b/deploy/charts/disco-agent/templates/rbac.yaml
@@ -110,3 +110,33 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "disco-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "disco-agent.fullname" . }}-eso-reader
+  labels:
+    {{- include "disco-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["external-secrets.io"]
+    resources:
+    - externalsecrets
+    - clusterexternalsecrets
+    - secretstores
+    - clustersecretstores
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "disco-agent.fullname" . }}-eso-reader
+  labels:
+    {{- include "disco-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "disco-agent.fullname" . }}-eso-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "disco-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
I was seeing issues in e2e tests in a separate PR with permissions for ESO resources. I'd thought that the way ESO was configured with the viewer role would mean the permissions were fine, but maybe it's best to be explicit anyway.

This _was_ caught in a [copilot review](https://github.com/jetstack/jetstack-secure/pull/780#discussion_r2841984018) on #780  but I really thought it wouldn't be a problem.

