### PR TITLE
disco: re-enable secret sending by default

### DIFF
--- a/deploy/charts/disco-agent/README.md
+++ b/deploy/charts/disco-agent/README.md
@@ -348,10 +348,10 @@ This description will be associated with the data that the agent uploads to the 
 #### **config.sendSecretValues** ~ `bool`
 > Default value:
 > ```yaml
-> false
+> true
 > ```
 
-Enable sending of Secret values to CyberArk in addition to metadata. Metadata is always sent, but the actual values of Secrets are not sent by default. When enabled, Secret data is encrypted using envelope encryption using a key managed by CyberArk, fetched from the Discovery and Context service. This value will default to "true" in a future release when further updates have been made to the Discovery and Context backend.
+Enable sending of Secret values to CyberArk in addition to metadata. Metadata is always sent, but the actual values of Secrets are not sent by default. When enabled, Secret data is encrypted using envelope encryption using a key managed by CyberArk, fetched from the Discovery and Context service.
 #### **authentication.secretName** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/disco-agent/templates/NOTES.txt
+++ b/deploy/charts/disco-agent/templates/NOTES.txt
@@ -9,6 +9,5 @@ APP VERSION: {{ .Chart.AppVersion }}
 > kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 {{ if .Values.config.sendSecretValues }}
-WARNING: sendSecretValues is not finalised and is subject to breaking changes in the future.
-It should be enabled only for testing and validation.
+NB: sendSecretValues is set to "true". Encrypted secret data will be sent to the CyberArk Discovery and Context service
 {{ end }}

--- a/deploy/charts/disco-agent/values.schema.json
+++ b/deploy/charts/disco-agent/values.schema.json
@@ -166,8 +166,8 @@
       "type": "string"
     },
     "helm-values.config.sendSecretValues": {
-      "default": false,
-      "description": "Enable sending of Secret values to CyberArk in addition to metadata. Metadata is always sent, but the actual values of Secrets are not sent by default. When enabled, Secret data is encrypted using envelope encryption using a key managed by CyberArk, fetched from the Discovery and Context service. This value will default to \"true\" in a future release when further updates have been made to the Discovery and Context backend.",
+      "default": true,
+      "description": "Enable sending of Secret values to CyberArk in addition to metadata. Metadata is always sent, but the actual values of Secrets are not sent by default. When enabled, Secret data is encrypted using envelope encryption using a key managed by CyberArk, fetched from the Discovery and Context service.",
       "type": "boolean"
     },
     "helm-values.extraArgs": {

--- a/deploy/charts/disco-agent/values.yaml
+++ b/deploy/charts/disco-agent/values.yaml
@@ -200,9 +200,7 @@ config:
   # Metadata is always sent, but the actual values of Secrets are not sent by default.
   # When enabled, Secret data is encrypted using envelope encryption using
   # a key managed by CyberArk, fetched from the Discovery and Context service.
-  # This value will default to "true" in a future release when further updates have been
-  # made to the Discovery and Context backend.
-  sendSecretValues: false
+  sendSecretValues: true
 
 authentication:
   secretName: agent-credentials


### PR DESCRIPTION
We got confirmation from the DisCo team that the encryption we're doing works as expected. As such, the next release of the DisCo agent should enable the secret sending by default, as we'd planned.