### PR TITLE
fix: rename image helper to avoid umbrella chart conflicts

### DIFF
--- a/deploy/charts/disco-agent/templates/_helpers.tpl
+++ b/deploy/charts/disco-agent/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 Util function for generating an image reference based on the provided options.
 This function is derived from similar functions used in the cert-manager GitHub organization
 */}}
-{{- define "image" -}}
+{{- define "disco-agent.image" -}}
 {{- /*
 Calling convention:
 - (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>)

--- a/deploy/charts/disco-agent/templates/_helpers.tpl
+++ b/deploy/charts/disco-agent/templates/_helpers.tpl
@@ -74,7 +74,7 @@ from `.Values` inside this helper, because `helm-tool lint` does not reliably tr
 usage through tuple/variable indirection.
 */ -}}
 {{- if ne (len .) 4 -}}
-	{{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+	{{- fail (printf "ERROR: template \"disco-agent.image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
 {{- end -}}
 {{- $image := index . 0 -}}
 {{- $imageRegistry := index . 1 | default "" -}}

--- a/deploy/charts/disco-agent/templates/deployment.yaml
+++ b/deploy/charts/disco-agent/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
+          image: "{{ template "disco-agent.image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: POD_NAMESPACE

--- a/deploy/charts/discovery-agent/templates/_helpers.tpl
+++ b/deploy/charts/discovery-agent/templates/_helpers.tpl
@@ -74,7 +74,7 @@ from `.Values` inside this helper, because `helm-tool lint` does not reliably tr
 usage through tuple/variable indirection.
 */ -}}
 {{- if ne (len .) 4 -}}
-	{{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+	{{- fail (printf "ERROR: template \"discovery-agent.image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
 {{- end -}}
 {{- $image := index . 0 -}}
 {{- $imageRegistry := index . 1 | default "" -}}

--- a/deploy/charts/discovery-agent/templates/_helpers.tpl
+++ b/deploy/charts/discovery-agent/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 Util function for generating an image reference based on the provided options.
 This function is derived from similar functions used in the cert-manager GitHub organization
 */}}
-{{- define "image" -}}
+{{- define "discovery-agent.image" -}}
 {{- /*
 Calling convention:
 - (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>)

--- a/deploy/charts/discovery-agent/templates/deployment.yaml
+++ b/deploy/charts/discovery-agent/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
+          image: "{{ template "discovery-agent.image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: POD_NAMESPACE

--- a/deploy/charts/venafi-kubernetes-agent/templates/_helpers.tpl
+++ b/deploy/charts/venafi-kubernetes-agent/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 Util function for generating an image reference based on the provided options.
 This function is derviced from similar functions used in the cert-manager GitHub organization
 */}}
-{{- define "image" -}}
+{{- define "venafi-kubernetes-agent.image" -}}
 {{- /*
 Calling convention:
 - (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>)

--- a/deploy/charts/venafi-kubernetes-agent/templates/_helpers.tpl
+++ b/deploy/charts/venafi-kubernetes-agent/templates/_helpers.tpl
@@ -74,7 +74,7 @@ from `.Values` inside this helper, because `helm-tool lint` does not reliably tr
 usage through tuple/variable indirection.
 */ -}}
 {{- if ne (len .) 4 -}}
-	{{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+	{{- fail (printf "ERROR: template \"venafi-kubernetes-agent.image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
 {{- end -}}
 {{- $image := index . 0 -}}
 {{- $imageRegistry := index . 1 | default "" -}}

--- a/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
+++ b/deploy/charts/venafi-kubernetes-agent/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
+          image: "{{ template "venafi-kubernetes-agent.image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" .Chart.AppVersion)) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: POD_NAMESPACE


### PR DESCRIPTION
Part of a group of PRs aiming to fix the issues reported here:

https://github.com/cert-manager/google-cas-issuer/issues/487

https://github.com/cert-manager/trust-manager/issues/908