### PR TITLE
[VC-52458] Support both number and string for tsgID

### DIFF
--- a/deploy/charts/discovery-agent/README.md
+++ b/deploy/charts/discovery-agent/README.md
@@ -6,13 +6,13 @@ The Discovery Agent connects your Kubernetes or OpenShift cluster to Palo Alto N
 
 <!-- AUTO-GENERATED -->
 
-#### **config.tsgID** ~ `string`
+#### **config.tsgID** ~ `number,string`
 > Default value:
 > ```yaml
 > ""
 > ```
 
-Required: The TSG (Tenant Service Group) ID to use when connecting to SCM. NB: TSG IDs are numeric, but must be treated as strings to avoid issues with YAML data types. With the Helm CLI use `--set-string`; with YAML always pass TSG IDs in double quotes.
+Required: The TSG (Tenant Service Group) ID to use when connecting to SCM.
 
 
 #### **config.clusterName** ~ `string`

--- a/deploy/charts/discovery-agent/templates/_helpers.tpl
+++ b/deploy/charts/discovery-agent/templates/_helpers.tpl
@@ -104,3 +104,22 @@ usage through tuple/variable indirection.
 	{{- printf "%s" $defaultReference -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Because of Helm bug (https://github.com/helm/helm/issues/3001), Helm converts
+int value to float64 implictly, like 2748336 becomes 2.748336e+06.
+This breaks the output even when using quote to render.
+
+Use this function when you want to get the string value only.
+It handles the case when the value is string itself as well.
+Parameters: is string/number
+
+Usage: {{ include "discovery-agent.stringOrNumber" .Values.config.tsgID }}
+*/}}
+{{- define "discovery-agent.stringOrNumber" -}}
+{{- if kindIs "string" . }}
+  {{- print . -}}
+{{- else  }}
+  {{- int64 . | toString -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/discovery-agent/templates/deployment.yaml
+++ b/deploy/charts/discovery-agent/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - "/etc/discovery-agent/config.yaml"
             - --ngts
             - --tsg-id
-            - {{ required "config.tsgID is required" .Values.config.tsgID | toString | quote }}
+            - {{ required "config.tsgID is required" .Values.config.tsgID | include "discovery-agent.stringOrNumber" | quote }}
             {{- with .Values.config.serverURL }}
             - --ngts-server-url
             - {{ . | quote }}

--- a/deploy/charts/discovery-agent/values.schema.json
+++ b/deploy/charts/discovery-agent/values.schema.json
@@ -183,8 +183,7 @@
     },
     "helm-values.config.tsgID": {
       "default": "",
-      "description": "Required: The TSG (Tenant Service Group) ID to use when connecting to SCM. NB: TSG IDs are numeric, but must be treated as strings to avoid issues with YAML data types. With the Helm CLI use `--set-string`; with YAML always pass TSG IDs in double quotes.",
-      "type": "string"
+      "description": "Required: The TSG (Tenant Service Group) ID to use when connecting to SCM."
     },
     "helm-values.extraArgs": {
       "default": [],

--- a/deploy/charts/discovery-agent/values.yaml
+++ b/deploy/charts/discovery-agent/values.yaml
@@ -1,10 +1,8 @@
 # Configuration for the Discovery Agent
 config:
   # Required: The TSG (Tenant Service Group) ID to use when connecting to SCM.
-  # NB: TSG IDs are numeric, but must be treated as strings to avoid issues with YAML data types.
-  # With the Helm CLI use `--set-string`; with YAML always pass TSG IDs in double quotes.
   # +docs:property
-  # +docs:type=string
+  # +docs:type=number,string
   tsgID: ""
 
   # Required: A human readable name for the cluster into which the agent is being deployed.


### PR DESCRIPTION
Based on feedback, this change updates tsgID to accept both numbers and strings.
Previously, the Helm chart’s values.schema.json enforced tsgID as a string. However, this constraint introduced unnecessary friction for users during initial setup.
To improve the user experience, we now allow both numeric and string inputs. As a side effect, this adds some complexity to the chart implementation, requiring a workaround for a Helm issue related to scientific notation handling.

context: in https://github.com/jetstack/jetstack-secure/pull/793 we enforced tsgID to be a string

```console
$ helm template ./deploy/charts/discovery-agent \
    --set config.tsgID=111111111111111111111111 \
    --set config.clusterName=aaa | grep 1111
            - "111111111111111111111111"
```