### PR TITLE
[VC-52277] Add cert-manager gatherers to discovery-agent

### DIFF
--- a/deploy/charts/discovery-agent/templates/configmap.yaml
+++ b/deploy/charts/discovery-agent/templates/configmap.yaml
@@ -76,3 +76,31 @@ data:
         resource-type:
           version: v1
           resource: pods
+    - kind: k8s-dynamic
+      name: k8s/certificates
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: certificates
+    - kind: k8s-dynamic
+      name: k8s/certificaterequests
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: certificaterequests
+    - kind: k8s-dynamic
+      name: k8s/issuers
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: issuers
+    - kind: k8s-dynamic
+      name: k8s/clusterissuers
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: clusterissuers


### PR DESCRIPTION
## Purpose

Without **k8s/certificates**, **k8s/issuers** and **k8s/clusterissuers** the TLSPK backend cannot determine cert-manager lifecycle for discovered certificates, causing all certs to show as `NOT_MANAGED` in the clusters page.