### PR TITLE
Add discovery-agent collection for CRD types

### DIFF
--- a/deploy/charts/discovery-agent/templates/configmap.yaml
+++ b/deploy/charts/discovery-agent/templates/configmap.yaml
@@ -23,7 +23,7 @@ data:
     {{- end }}
     data-gatherers:
     - kind: k8s-discovery
-      name: k8s/discovery
+      name: k8s-discovery
     - kind: k8s-dynamic
       name: k8s/secrets
       config:
@@ -76,3 +76,198 @@ data:
         resource-type:
           version: v1
           resource: pods
+    - kind: "k8s-dynamic"
+      name: "k8s/namespaces"
+      config:
+        resource-type:
+          resource: namespaces
+          version: v1
+    # gather services for pod readiness probe rules
+    - kind: "k8s-dynamic"
+      name: "k8s/services"
+      config:
+        resource-type:
+          resource: services
+          version: v1
+    - kind: "k8s-dynamic"
+      name: "k8s/ingresses"
+      config:
+        resource-type:
+          group: networking.k8s.io
+          version: v1
+          resource: ingresses
+    - kind: "k8s-dynamic"
+      name: "k8s/certificates"
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: certificates
+    - kind: "k8s-dynamic"
+      name: "k8s/certificaterequests"
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: certificaterequests
+    - kind: "k8s-dynamic"
+      name: "k8s/issuers"
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: issuers
+    - kind: "k8s-dynamic"
+      name: "k8s/clusterissuers"
+      config:
+        resource-type:
+          group: cert-manager.io
+          version: v1
+          resource: clusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/googlecasissuers"
+      config:
+        resource-type:
+          group: cas-issuer.jetstack.io
+          version: v1beta1
+          resource: googlecasissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/googlecasclusterissuers"
+      config:
+        resource-type:
+          group: cas-issuer.jetstack.io
+          version: v1beta1
+          resource: googlecasclusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/awspcaissuer"
+      config:
+        resource-type:
+          group: awspca.cert-manager.io
+          version: v1beta1
+          resource: awspcaissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/awspcaclusterissuers"
+      config:
+        resource-type:
+          group: awspca.cert-manager.io
+          version: v1beta1
+          resource: awspcaclusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/mutatingwebhookconfigurations"
+      config:
+        resource-type:
+          group: admissionregistration.k8s.io
+          version: v1
+          resource: mutatingwebhookconfigurations
+    - kind: "k8s-dynamic"
+      name: "k8s/validatingwebhookconfigurations"
+      config:
+        resource-type:
+          group: admissionregistration.k8s.io
+          version: v1
+          resource: validatingwebhookconfigurations
+    - kind: "k8s-dynamic"
+      name: "k8s/gateways"
+      config:
+        resource-type:
+          group: networking.istio.io
+          version: v1alpha3
+          resource: gateways
+    - kind: "k8s-dynamic"
+      name: "k8s/virtualservices"
+      config:
+        resource-type:
+          group: networking.istio.io
+          version: v1alpha3
+          resource: virtualservices
+    - kind: "k8s-dynamic"
+      name: "k8s/routes"
+      config:
+        resource-type:
+          version: v1
+          group: route.openshift.io
+          resource: routes
+    - kind: "k8s-dynamic"
+      name: "k8s/venaficonnections"
+      config:
+        resource-type:
+          group: jetstack.io
+          version: v1alpha1
+          resource: venaficonnections
+    - kind: "k8s-dynamic"
+      name: "k8s/venaficlusterissuers"
+      config:
+        resource-type:
+          group: jetstack.io
+          version: v1alpha1
+          resource: venaficlusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/venafiissuers"
+      config:
+        resource-type:
+          group: jetstack.io
+          version: v1alpha1
+          resource: venafiissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/fireflyissuers"
+      config:
+        resource-type:
+          group: firefly.venafi.com
+          version: v1
+          resource: issuers
+    - kind: "k8s-dynamic"
+      name: "k8s/stepissuers"
+      config:
+        resource-type:
+          group: certmanager.step.sm
+          version: v1beta1
+          resource: stepissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/stepclusterissuers"
+      config:
+        resource-type:
+          group: certmanager.step.sm
+          version: v1beta1
+          resource: stepclusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/originissuers"
+      config:
+        resource-type:
+          group: cert-manager.k8s.cloudflare.com
+          version: v1
+          resource: originissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/clusteroriginissuers"
+      config:
+        resource-type:
+          group: cert-manager.k8s.cloudflare.com
+          version: v1
+          resource: clusteroriginissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/freeipaissuers"
+      config:
+        resource-type:
+          group: certmanager.freeipa.org
+          version: v1beta1
+          resource: issuers
+    - kind: "k8s-dynamic"
+      name: "k8s/freeipaclusterissuers"
+      config:
+        resource-type:
+          group: certmanager.freeipa.org
+          version: v1beta1
+          resource: clusterissuers
+    - kind: "k8s-dynamic"
+      name: "k8s/ejbcaissuers"
+      config:
+        resource-type:
+          group: ejbca-issuer.keyfactor.com
+          version: v1alpha1
+          resource: issuers
+    - kind: "k8s-dynamic"
+      name: "k8s/ejbcaclusterissuers"
+      config:
+        resource-type:
+          group: ejbca-issuer.keyfactor.com
+          version: v1alpha1
+          resource: clusterissuers

--- a/deploy/charts/discovery-agent/templates/rbac.yaml
+++ b/deploy/charts/discovery-agent/templates/rbac.yaml
@@ -110,3 +110,41 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "discovery-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "discovery-agent.fullname" . }}-crd-reader
+  labels:
+    {{- include "discovery-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - cert-manager.io
+    - cas-issuer.jetstack.io
+    - awspca.cert-manager.io
+    - jetstack.io
+    - firefly.venafi.com
+    - certmanager.step.sm
+    - cert-manager.k8s.cloudflare.com
+    - certmanager.freeipa.org
+    - ejbca-issuer.keyfactor.com
+    - networking.istio.io
+    - route.openshift.io
+    - admissionregistration.k8s.io
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "discovery-agent.fullname" . }}-crd-reader
+  labels:
+    {{- include "discovery-agent.labels" . | nindent 4 }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "discovery-agent.fullname" . }}-crd-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "discovery-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/discovery-agent/tests/rbac_test.yaml
+++ b/deploy/charts/discovery-agent/tests/rbac_test.yaml
@@ -3,15 +3,6 @@ templates:
   - rbac.yaml
 
 tests:
-  # Test that all RBAC resources are created
-  - it: should create all RBAC resources
-    set:
-      config.clusterName: test-cluster
-      config.tsgID: "123456"
-    asserts:
-      - hasDocuments:
-          count: 8
-
   # Test Role for event emission
   - it: should create Role for event emission
     set:
@@ -181,3 +172,59 @@ tests:
       - equal:
           path: roleRef.name
           value: system:service-account-issuer-discovery
+
+  # Test ClusterRole for CRD reader
+  - it: should create ClusterRole for CRD reader
+    set:
+      config.clusterName: test-cluster
+      config.tsgID: "123456"
+    documentIndex: 8
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-discovery-agent-crd-reader
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - cert-manager.io
+              - cas-issuer.jetstack.io
+              - awspca.cert-manager.io
+              - jetstack.io
+              - firefly.venafi.com
+              - certmanager.step.sm
+              - cert-manager.k8s.cloudflare.com
+              - certmanager.freeipa.org
+              - ejbca-issuer.keyfactor.com
+              - networking.istio.io
+              - route.openshift.io
+              - admissionregistration.k8s.io
+            resources: ["*"]
+            verbs: ["get", "list", "watch"]
+
+  # Test ClusterRoleBinding for CRD reader
+  - it: should create ClusterRoleBinding for CRD reader
+    set:
+      config.clusterName: test-cluster
+      config.tsgID: "123456"
+    documentIndex: 9
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-discovery-agent-crd-reader
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-discovery-agent-crd-reader
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: RELEASE-NAME-discovery-agent
+            namespace: NAMESPACE


### PR DESCRIPTION
This broadly matches what was present in venafi-kubernetes-agent; this is an alternative to #799 