### PR TITLE
excludeAnnotationKeysRegex bug fix

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -196,8 +196,8 @@ func Run(cmd *cobra.Command, args []string) (returnErr error) {
 
 		dynDg, isDynamicGatherer := newDg.(*k8sdynamic.DataGathererDynamic)
 		if isDynamicGatherer {
-			dynDg.ExcludeAnnotKeys = config.ExcludeAnnotationKeysRegex
-			dynDg.ExcludeLabelKeys = config.ExcludeLabelKeysRegex
+			dynDg.ExcludeAnnotKeys = append(dynDg.ExcludeAnnotKeys, config.ExcludeAnnotationKeysRegex...)
+			dynDg.ExcludeLabelKeys = append(dynDg.ExcludeLabelKeys, config.ExcludeLabelKeysRegex...)
 
 			gvr := dynDg.GVR()
 


### PR DESCRIPTION
The global exclude-annotation-keys-regex was overwriting per-gatherer excludeAnnotationKeysRegex, meaning per-gatherer didn't work. Changed the assignment in run.go to an append so both levels are respected.

Closes [VC-53256](https://venafi.atlassian.net/jira/software/c/projects/VC/boards/155?assignee=712020%3Ac2f49bd1-2a65-47b4-8e58-b1188e929362&selectedIssue=VC-53256)

[VC-53256]: https://venafi.atlassian.net/browse/VC-53256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ