### PR TITLE
feat(agent): add jwtsource package for reading projected SA tokens

### DIFF
--- a/internal/cyberark/jwtsource/jwtsource.go
+++ b/internal/cyberark/jwtsource/jwtsource.go
@@ -1,0 +1,39 @@
+// internal/cyberark/jwtsource/jwtsource.go
+package jwtsource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// DefaultTokenPath is the default projected ServiceAccount token mount (aud=conjur).
+const DefaultTokenPath = "/var/run/secrets/tokens/jwt"
+
+// Source produces a raw JWT to exchange at SMS authn-jwt.
+type Source interface {
+	Read(ctx context.Context) (string, error)
+}
+
+type fileSource struct{ path string }
+
+// NewFileSource reads a JWT from a file (the projected SA token).
+func NewFileSource(path string) Source {
+	if path == "" {
+		path = DefaultTokenPath
+	}
+	return &fileSource{path: path}
+}
+
+func (f *fileSource) Read(_ context.Context) (string, error) {
+	b, err := os.ReadFile(f.path)
+	if err != nil {
+		return "", fmt.Errorf("jwt source file %q not found or unreadable (is the projected serviceAccountToken volume mounted?): %w", f.path, err)
+	}
+	tok := strings.TrimSpace(string(b))
+	if tok == "" {
+		return "", fmt.Errorf("jwt source file %q is empty", f.path)
+	}
+	return tok, nil
+}

--- a/internal/cyberark/jwtsource/jwtsource_test.go
+++ b/internal/cyberark/jwtsource/jwtsource_test.go
@@ -1,0 +1,32 @@
+// internal/cyberark/jwtsource/jwtsource_test.go
+package jwtsource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileSource_ReadsToken(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "jwt")
+	require.NoError(t, os.WriteFile(p, []byte("the-jwt\n"), 0o600))
+	got, err := NewFileSource(p).Read(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "the-jwt", got) // trimmed
+}
+
+func TestFileSource_MissingFile(t *testing.T) {
+	_, err := NewFileSource("/no/such/file").Read(t.Context())
+	require.Error(t, err)
+}
+
+func TestFileSource_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "jwt")
+	require.NoError(t, os.WriteFile(p, []byte("  \n"), 0o600))
+	_, err := NewFileSource(p).Read(t.Context())
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
Part 1 of the SMS/Conjur JWT authentication series (split out of #817 for reviewability).

Introduces a small, isolated interface for reading a JWT from a file path — the first piece of the upcoming Conjur JWT authentication path. Nothing else depends on it in this PR; the Conjur client that uses it lands later in the stack.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cyberark/jwtsource/...`