### PR TITLE
CP-21164: fix cyberark validation tests picking up ambient ARK_USERNAME/ARK_SECRET secrets

### DIFF
--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -1323,11 +1323,19 @@ func Test_ValidateAndCombineConfig_NGTS(t *testing.T) {
 
 func TestConfig_CyberArk_Validation(t *testing.T) {
 	// Common env setup: ARK_SUBDOMAIN is the only required env var for MachineHub mode.
+	// ARK_USERNAME/ARK_SECRET are cleared unconditionally rather than left
+	// ambient — CI sets both from real secrets at the job level (for the
+	// separate ARK_LIVE_TEST-gated live test), so leaving them untouched here
+	// would let real credentials leak into subtests that assert on an empty
+	// username/secret. Subtests needing non-empty values set them explicitly
+	// after calling setEnv.
 	setEnv := func(t *testing.T) {
 		t.Helper()
 		t.Setenv("POD_NAMESPACE", "venafi")
 		t.Setenv("KUBECONFIG", withFile(t, fakeKubeconfig))
 		t.Setenv("ARK_SUBDOMAIN", "tlspk")
+		t.Setenv("ARK_USERNAME", "")
+		t.Setenv("ARK_SECRET", "")
 	}
 
 	// service_id is not required at config-validation time as long as the


### PR DESCRIPTION
## Summary

Post-merge CI on `master` failed after #818-824 merged: https://github.com/jetstack/jetstack-secure/actions/runs/33077373972/job/98535010580

Three `TestConfig_CyberArk_Validation` subtests in `pkg/agent/config_test.go` assumed `ARK_USERNAME`/`ARK_SECRET` were empty in the ambient environment. That holds locally, but this repo's `tests.yaml` workflow sets both from real repo secrets at the job level (for the separate `ARK_LIVE_TEST`-gated live test), so the subtests picked up real credentials instead of an empty baseline — causing assertions like "neither service_id nor ARK_USERNAME is an error" to unexpectedly pass with no error.

## Fix

The shared `setEnv` helper in that test now clears `ARK_USERNAME`/`ARK_SECRET` unconditionally before each subtest; subtests that need non-empty values still set them explicitly afterward via their own `t.Setenv` calls.

## Test plan

- [x] Reproduced the exact 3 failures locally by setting `ARK_SUBDOMAIN`/`ARK_USERNAME`/`ARK_SECRET` env vars before running `go test ./pkg/agent/...`, matching CI's failure output exactly (including the fallback/cluster_name assertion).
- [x] Confirmed the fix passes under the same simulated ambient-secret condition.
- [x] Full `go build ./...`, `go test ./...`, and `golangci-lint run ./...` pass (one pre-existing, unrelated `pkg/client` failure from a local Go-toolchain stdlib message difference, confirmed present at `master` before this change too).