### PR TITLE
CP-21164: run e2e-tests since they don't run on PRs from forks

### DIFF
--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -1323,11 +1323,19 @@ func Test_ValidateAndCombineConfig_NGTS(t *testing.T) {
 
 func TestConfig_CyberArk_Validation(t *testing.T) {
 	// Common env setup: ARK_SUBDOMAIN is the only required env var for MachineHub mode.
+	// ARK_USERNAME/ARK_SECRET are cleared unconditionally rather than left
+	// ambient — CI sets both from real secrets at the job level (for the
+	// separate ARK_LIVE_TEST-gated live test), so leaving them untouched here
+	// would let real credentials leak into subtests that assert on an empty
+	// username/secret. Subtests needing non-empty values set them explicitly
+	// after calling setEnv.
 	setEnv := func(t *testing.T) {
 		t.Helper()
 		t.Setenv("POD_NAMESPACE", "venafi")
 		t.Setenv("KUBECONFIG", withFile(t, fakeKubeconfig))
 		t.Setenv("ARK_SUBDOMAIN", "tlspk")
+		t.Setenv("ARK_USERNAME", "")
+		t.Setenv("ARK_SECRET", "")
 	}
 
 	// service_id is not required at config-validation time as long as the


### PR DESCRIPTION
Closes #825

Re-raises #825 from a branch in this repository rather than a fork, and carries the same
one commit (cherry-picked, original author preserved).

## Why re-raise it here

The label-gated e2e jobs in `.github/workflows/tests.yaml` — `ark-test-e2e` (`test-ark`),
`ngts-test-e2e` (`test-ngts`) and `test-e2e` (`test-e2e`) — all depend on repository
secrets (`GCP_SA_KEY`, `ARK_SUBDOMAIN`/`ARK_USERNAME`/`ARK_SECRET`, `ARK_OCI_BASE`,
`NGTS_PRIVATE_KEY`). GitHub does not expose secrets to `pull_request` runs from forks, so
those jobs cannot pass — or even meaningfully run — on #825. Granting write access to the
fork's author wasn't an option, so the branch lives here instead.

With the three labels applied, all e2e jobs run on this PR.

## What the change fixes

`TestConfig_CyberArk_Validation` was added alongside the Conjur JWT work and asserts on
behaviour that only holds when `ARK_USERNAME`/`ARK_SECRET` are unset. The `test` job in
`tests.yaml` sets both from real secrets at the job level (they exist for the separate
`ARK_LIVE_TEST`-gated live test), so those subtests inherit real credentials and fail on
`master`:

- `neither service_id nor ARK_USERNAME is an error at config time`
- `ARK_USERNAME without ARK_SECRET is an error at config time`
- `cluster_name is empty when cluster_name, cluster_id, and ARK_USERNAME are all unset`

The fix clears both variables in the shared `setEnv` helper so the subtests are hermetic.
Subtests that need non-empty values set them after calling `setEnv`, so nothing is
clobbered. This is a test-isolation fix only — no production code changes.
