### PR TITLE
test: document why the migration-precedence test already proves Conjur wins over username/password

### DIFF
--- a/pkg/client/client_cyberark_test.go
+++ b/pkg/client/client_cyberark_test.go
@@ -28,18 +28,10 @@ import (
 // The environment variables are chosen to match those expected by the mock
 // server.
 //
-// ARK_USERNAME/ARK_SECRET are set here deliberately, alongside a non-empty
-// serviceID (test plan Track F, case F2 -- migrating install, add serviceId
-// while old creds are still present). This is not incidental: it is the
-// integration-level proof that selectAuthenticator's Conjur-wins precedence
-// actually holds through the full NewCyberArk/PostDataReadingsWithOptions
-// path, not just in the selectAuthenticator unit tests (auth_select_test.go).
-// It works because FakeCyberArk's Identity.API is an unreachable
-// `.invalid` host: if the username/password path were mistakenly chosen
-// instead of Conjur, the login attempt would fail with a connection error
-// and this test would fail. Do not remove these two lines as "unnecessary" --
-// doing so would silently delete this test's only coverage of migration
-// precedence.
+// ARK_USERNAME/ARK_SECRET are set here on purpose alongside a non-empty
+// serviceID: selectAuthenticator ignores them once serviceID is set, and
+// FakeCyberArk's Identity.API is an unreachable `.invalid` host -- a
+// mistaken fallback to username/password would fail this test.
 func TestCyberArkClient_PostDataReadingsWithOptions_MockAPI(t *testing.T) {
 	t.Setenv("ARK_SUBDOMAIN", servicediscovery.MockDiscoverySubdomain)
 	t.Setenv("ARK_USERNAME", "test@example.com")
@@ -60,12 +52,9 @@ func TestCyberArkClient_PostDataReadingsWithOptions_MockAPI(t *testing.T) {
 }
 
 // TestCyberArkClient_PostDataReadingsWithOptions_UsernamePasswordMockAPI is
-// the legacy-auth-path counterpart to the Conjur test above. Without it, the
-// only integration-level test of NewCyberArk's username/password path is one
-// that sets ARK_USERNAME/ARK_SECRET but then also passes a non-empty
-// serviceID — which selectAuthenticator prioritises, so it silently exercises
-// Conjur regardless of those env vars. This test leaves serviceID empty so
-// the username/password path is what's actually under test.
+// the legacy-auth-path counterpart to the Conjur test above (see its comment
+// for why serviceID must stay empty here for this test to actually exercise
+// the username/password path).
 func TestCyberArkClient_PostDataReadingsWithOptions_UsernamePasswordMockAPI(t *testing.T) {
 	t.Setenv("ARK_SUBDOMAIN", servicediscovery.MockDiscoverySubdomain)
 	httpClient, username, password := testutil.FakeCyberArkUsernamePassword(t)

--- a/pkg/client/client_cyberark_test.go
+++ b/pkg/client/client_cyberark_test.go
@@ -27,6 +27,19 @@ import (
 // dataupload code works with the mock CyberArk APIs.
 // The environment variables are chosen to match those expected by the mock
 // server.
+//
+// ARK_USERNAME/ARK_SECRET are set here deliberately, alongside a non-empty
+// serviceID (test plan Track F, case F2 -- migrating install, add serviceId
+// while old creds are still present). This is not incidental: it is the
+// integration-level proof that selectAuthenticator's Conjur-wins precedence
+// actually holds through the full NewCyberArk/PostDataReadingsWithOptions
+// path, not just in the selectAuthenticator unit tests (auth_select_test.go).
+// It works because FakeCyberArk's Identity.API is an unreachable
+// `.invalid` host: if the username/password path were mistakenly chosen
+// instead of Conjur, the login attempt would fail with a connection error
+// and this test would fail. Do not remove these two lines as "unnecessary" --
+// doing so would silently delete this test's only coverage of migration
+// precedence.
 func TestCyberArkClient_PostDataReadingsWithOptions_MockAPI(t *testing.T) {
 	t.Setenv("ARK_SUBDOMAIN", servicediscovery.MockDiscoverySubdomain)
 	t.Setenv("ARK_USERNAME", "test@example.com")


### PR DESCRIPTION
## Summary

- `TestCyberArkClient_PostDataReadingsWithOptions_MockAPI` already sets both a non-empty Conjur `serviceID` and `ARK_USERNAME`/`ARK_SECRET` together, and passes -- proving `selectAuthenticator`'s documented precedence (Conjur wins when both are set) actually holds. That property wasn't documented as deliberate, so it read as incidental copy-paste. Adds a doc comment making it explicit.
- Mechanism: `FakeCyberArk`'s `Identity.API` is an unreachable `.invalid` host, so if the username/password path were mistakenly chosen instead of Conjur, this test would fail with a connection error rather than silently passing against the wrong path.
- A few adjacent legacy-compatibility properties needed no new code: removing the old credentials after cutover is already covered by the existing Conjur-only test; routing both credential shapes correctly across tenants is server-side (already covered on the authorizer side); and an un-onboarded agent failing closed (no silent fallback) is structurally guaranteed by `selectAuthenticator`'s switch/case having no fallback branch once Conjur is chosen.

## Test plan

- [x] `go test ./pkg/client/... -run TestCyberArkClient_PostDataReadingsWithOptions_MockAPI -v` passes; log line confirms the precedence decision at runtime ("both Conjur service_id and ARK_USERNAME/ARK_SECRET are set; using the Conjur JWT exchange and ignoring the username/password credentials")
- [x] `go test ./pkg/client/... ./internal/cyberark/...` -- no new failures (2 pre-existing unrelated failures confirmed present on unmodified master too: `KUBEBUILDER_ASSETS` env requirement, and a known Go jsonv2 error-string drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)