### PR TITLE
Allow the e2e suites to be run manually against master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master]
   pull_request: {}
+  # Lets us run the e2e suites against master, which the label gates below
+  # cannot do: they read github.event.pull_request.labels, which is empty for
+  # a push. Needed before tagging a release.
+  workflow_dispatch: {}
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -80,7 +84,7 @@ jobs:
     # where the e2e fails with a 400 error relating to "conflicting tagging values"
     # The test is flaky, not broken and re-running eventually makes it pass - but that delays progress on
     # other unrelated work.
-    if: contains(github.event.pull_request.labels.*.name, 'test-ark')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ark')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -117,7 +121,7 @@ jobs:
 
   ngts-test-e2e:
     # TEMPORARY: require an explicit label to test NGTS until we have a stable test environment
-    if: contains(github.event.pull_request.labels.*.name, 'test-ngts')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ngts')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -151,7 +155,7 @@ jobs:
           NGTS_TSG_URL: https://1806660206.ngts.qa.venafi.io
 
   test-e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'test-e2e')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-e2e')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## Why now?

We want to run the e2e suites against master before tagging `v1.12.0-alpha.0`. Right now there is no way to do that.

All three e2e jobs are gated on `github.event.pull_request.labels`, which does not exist for a push event. So they skip on **every** push to master as well as on every unlabelled pull request. Nothing has run them on master for some time.

The workaround is to open a pull request and label it, which is what we did for #831. That has two problems: it tests the pull request's merge commit rather than master itself, and it has to be repeated by hand every release.

## What this changes

Adds `workflow_dispatch` and lets the three e2e gates fire on it:

```yaml
if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ark')
```

That gives a **Run workflow** button which runs all three suites against any ref, including master. The label route is unchanged for pull requests, so existing behaviour is untouched.

## Two things I checked rather than assumed

**The GKE cluster still gets deleted on a manual run.** The cleanup step is gated on `always() && !contains(github.event.pull_request.labels.*.name, 'keep-e2e-cluster')`. On a `workflow_dispatch` run `github.event.pull_request` is null, so the filter yields nothing, `contains` is false, and the negation is true. The cluster is cleaned up. The failure mode here would have been leaking a GKE cluster on every manual run, so it is worth being explicit that it does not.

**The cluster name does not depend on the pull request.** It is `test-secretless-$(date +'%y%m%d-%H%M%S')`, with a comment explaining that extracting from the PR name would need sanitising for GKE naming rules. So it is already safe outside a pull request context.

## One quirk to expect

The **Run workflow** button will not appear until this is merged. GitHub only reads `workflow_dispatch` from the workflow file on the default branch, so you cannot test the button from this pull request. The `if` expressions are the only new logic and they are plain string comparisons.

## Deliberately not doing yet

I have not added a `schedule`, and I have not made e2e run on every push to master. Both are tempting, but `ark-test-e2e` still carries its `TEMPORARY` comment about a recurring 400 "conflicting tagging values" error, described as flaky rather than broken. Making a known-flaky suite gate every merge would be worse than the current situation. A nightly schedule is the better long-term answer and is tracked internally along with the question of whether that flake is still real.

## Testing

`make verify` passes. The YAML parses and the three gates resolve as intended:

```
triggers: ['push', 'pull_request', 'workflow_dispatch']
ark-test-e2e  => github.event_name == 'workflow_dispatch' || contains(...'test-ark')
ngts-test-e2e => github.event_name == 'workflow_dispatch' || contains(...'test-ngts')
test-e2e      => github.event_name == 'workflow_dispatch' || contains(...'test-e2e')
```

The real proof is dispatching it against master once merged, which is the next step before tagging.
