### PR TITLE
Stop the VCP e2e test hanging when the certificate never appears

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,6 +86,7 @@ jobs:
     # other unrelated work.
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ark')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
@@ -123,6 +124,7 @@ jobs:
     # TEMPORARY: require an explicit label to test NGTS until we have a stable test environment
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-ngts')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
@@ -157,6 +159,9 @@ jobs:
   test-e2e:
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-e2e')
     runs-on: ubuntu-latest
+    # A healthy run takes about 15 minutes. The backstop matters because the job
+    # holds a GKE cluster for as long as it runs, and the default is 6 hours.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         # Adding `fetch-depth: 0` makes sure tags are also fetched. We need

--- a/hack/e2e/test.sh
+++ b/hack/e2e/test.sh
@@ -194,14 +194,13 @@ kubectl -n team-1 wait certificate app-0 --for=condition=Ready
 
 # Wait 60s for log message indicating success.
 # Parse logs as JSON using jq to ensure logs are all JSON formatted.
-# Disable pipefail to prevent SIGPIPE (141) errors from tee
-# See https://unix.stackexchange.com/questions/274120/pipe-fail-141-when-piping-output-into-tee-why
-set +o pipefail
-kubectl logs deployments/venafi-kubernetes-agent \
-        --follow \
-        --namespace venafi \
-    | timeout 60 jq 'if .msg | test("Data sent successfully") then . | halt_error(0) end'
-set -o pipefail
+#
+# Supply the logs by process substitution rather than a pipe, so that `timeout`
+# bounds jq itself. The pipe form has to disable pipefail to survive the SIGPIPE
+# it provokes in kubectl. Matches hack/ark/test-e2e.sh and hack/ngts/test-e2e.sh.
+timeout 60 jq -n \
+        'inputs | if .msg | test("Data sent successfully") then . | halt_error(0) else . end' \
+        <(kubectl logs deployments/venafi-kubernetes-agent --follow --namespace venafi)
 
 # Create a unique TLS Secret and wait for it to appear in the Venafi certificate
 # inventory API. The case conversion is due to macOS' version of uuidgen which
@@ -210,6 +209,9 @@ commonname="venafi-kubernetes-agent-e2e.$(uuidgen | tr '[:upper:]' '[:lower:]')"
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=$commonname"
 kubectl create secret tls "$commonname" --cert=/tmp/tls.crt --key=/tmp/tls.key -o yaml --dry-run=client | kubectl apply -f -
 
+# --max-time bounds the poll itself. curl has no default overall limit, and the
+# deadline below is only checked between polls, so a connection that stalls
+# after being accepted would hang here and never reach it.
 getCertificate() {
     jq -n '{
         "expression": {
@@ -226,10 +228,24 @@ getCertificate() {
     }' --arg commonname "${commonname}" \
     | curl "https://${VEN_API_HOST}/outagedetection/v1/certificatesearch?excludeSupersededInstances=true&ownershipTree=true" \
          -fsSL \
+         --max-time 30 \
          -H "tppl-api-key: $VEN_API_KEY" \
          --json @- \
     | jq 'if .count == 0 then . | halt_error(1) end'
 }
 
 # Wait 5 minutes for the certificate to appear.
-for ((i=0;;i++)); do if getCertificate; then exit 0; fi; sleep 30; done | timeout -v -- 5m cat
+#
+# Do not put the retry loop on the left of a pipe into `timeout`. That only
+# bounds the reader: while getCertificate is failing the loop writes nothing, so
+# it never takes a SIGPIPE, and Bash blocks forever waiting for it after
+# `timeout` has killed `cat`.
+certificate_timeout_seconds=300
+deadline=$((SECONDS + certificate_timeout_seconds))
+until getCertificate; do
+  if ((SECONDS >= deadline)); then
+    echo "Timed out after ${certificate_timeout_seconds}s waiting for certificate ${commonname} to appear in the Venafi inventory" >&2
+    exit 1
+  fi
+  sleep 30
+done


### PR DESCRIPTION
The VCP e2e test can hang forever. This makes it fail instead.

## Why now?

Run [34356382122](https://github.com/jetstack/jetstack-secure/actions/runs/34356382122) sat on one step for 50 minutes and I cancelled it by hand. Left alone it would have held a GKE cluster until the default six hour job timeout. A healthy run takes about 14 minutes.

The final wait in `hack/e2e/test.sh` cannot time out:

```bash
for ((i=0;;i++)); do if getCertificate; then exit 0; fi; sleep 30; done | timeout -v -- 5m cat
```

`timeout` bounds `cat`, not the loop. While `getCertificate` is failing it writes nothing to the pipe, so it never takes a SIGPIPE. When `timeout` kills `cat` at five minutes, Bash blocks forever waiting for the loop, which is still going. The `exit 0` on success only leaves the subshell, so it cannot end the script either.

The cancelled run shows how bad this gets: the certificate **did** eventually arrive, and the test could no longer see it. Detail below.

## What changes

- The certificate wait becomes a plain deadline loop. It now fails at five minutes with a message naming the certificate it gave up on.
- `getCertificate`'s curl gets `--max-time 30`. curl sets no default overall limit and the deadline is only checked between polls, so a connection that stalls once accepted would hang inside the poll and never reach the check. Same class of hang, moved from the loop into the request. Raised by @FelixPhipps in review.
- The log wait above it moves to the process substitution form already used by `hack/ark/test-e2e.sh` and `hack/ngts/test-e2e.sh`, which lets `timeout` bound `jq` directly. That one was not broken, but it only worked because `kubectl` keeps writing and so does take a SIGPIPE, which is why it needed `set +o pipefail` wrapped around it. That dance goes away.
- The three e2e jobs get a `timeout-minutes`. They had none, so the default six hours applied. This is a backstop, not the fix.

## What this does not fix

This run would still have failed, just promptly and with a clear message. Two separate problems, both worth their own change:

- **The certificate took about 22 minutes to appear in the inventory.** The five minute budget is unchanged here. If that latency is normal now rather than a blip, the budget needs revisiting on its own evidence.
- **Every run leaks two Venafi service accounts** — the registry one created around line 90 and the agent one created in the unbounded `while true` loop around line 140. Nothing deletes them, and `$RANDOM` only spans 0–32767. That loop also has no `sleep`, so if it ever fails to converge it will hammer the API rather than stall. Its curls are unbounded too, as are the rest in the script; only `getCertificate`'s is fixed here.

<details>
<summary>Timeline from the cancelled run, showing the certificate arriving after the reader was already dead</summary>

| Time (UTC) | What the log shows |
| --- | --- |
| 13:28:54 | Polling begins |
| 13:33:54 | `timeout: sending signal TERM to command 'cat'` — five minute budget expires, reader dies, script does not exit |
| 13:34–13:50 | Loop keeps polling a dead pipe, logging `{"count":0,"certificates":[]}` to stderr |
| 13:50:36 | Output flips to `jq: error: writing output failed: Broken pipe` |
| 14:13:54 | Cancelled by hand |

That last line is the important one. `getCertificate` ends in:

```bash
| jq 'if .count == 0 then . | halt_error(1) end'
```

`halt_error` writes to stderr, which is why the `count":0` lines still reach the log after the pipe is gone. jq only attempts a **stdout** write when the condition is false, so a broken pipe error means `count` was non-zero. The certificate had landed at 13:50:36, roughly 22 minutes after polling began and 17 minutes after the reader was killed.

</details>

<details>
<summary>How this was tested, given the e2e itself needs a GKE cluster and a live tenant</summary>

I extracted both wait constructs into standalone harnesses and drove them with a stub that succeeds and one that never does.

Old certificate wait, stub that never succeeds, outer kill after 25s:

```
start 1788963103
timeout: sending signal TERM to command 'cat'
outer exit=124 (124 = the script never returned)
```

`timeout` fired at 5s and the script still had to be killed from outside.

Replacement, same stub:

```
Timed out after 5s waiting for certificate example.test to appear in the Venafi inventory
case1 (never appears) exit=1
```

Replacement, stub that succeeds at 4s:

```
{"count":1}
SUCCESS: fell through to end of script
case2 (appears at 4s) exit=0
```

New log wait, stream that emits the success line:

```
{"msg":"Data sent successfully"}
match: exit=0 (want 0, fast)
```

New log wait, stream that never emits it:

```
nomatch: exit=124 (want 124, no hang)
```

`bash -n` passes on the script and the workflow parses as valid YAML with the three new timeouts in place.

</details>

## e2e result

Green: [run 34373985024](https://github.com/jetstack/jetstack-secure/actions/runs/34373985024), 15m10s against the ~14 minute baseline, with the `test-e2e` label.

Both changed waits were exercised, so it is not a pass by luck. The log wait matched `Data sent successfully` and returned; the deadline loop polled four times at 30s intervals and hit on the fourth, about 90 seconds in. There is **not one** `jq: error: writing output failed: Broken pipe` in the log, which was the old bug's signature.

That also settles the latency question above: this morning's ~22 minutes was a blip, not the new normal, so the five minute budget stands.

Note for the label route: adding the label alone does not start a run. `on: pull_request: {}` uses the default activity types — `opened`, `synchronize`, `reopened` — and `labeled` is not among them. Label, then push.
